### PR TITLE
Private-store price multiplier, GM-shop buy fix, //rates panel, buff …

### DIFF
--- a/.github/workflows/java-parsing-tests.yml
+++ b/.github/workflows/java-parsing-tests.yml
@@ -10,6 +10,7 @@ on:
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java"
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java"
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerNameFactory.java"
+      - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java"
       - "L2J_Mobius_CT_0_Interlude github/tests/java/**"
       - ".github/workflows/java-parsing-tests.yml"
   push:
@@ -19,6 +20,7 @@ on:
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java"
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java"
       - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerNameFactory.java"
+      - "L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java"
       - "L2J_Mobius_CT_0_Interlude github/tests/java/**"
       - ".github/workflows/java-parsing-tests.yml"
 
@@ -46,7 +48,9 @@ jobs:
             "java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java" \
             "java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java" \
             "java/org/l2jmobius/gameserver/managers/FakePlayerNameFactory.java" \
+            "java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java" \
             tests/java/*.java
           java -cp build/test-classes FakePlayerChatParsingTest
           java -cp build/test-classes FakePlayerStorePricingTest
           java -cp build/test-classes FakePlayerNameFactoryTest
+          java -cp build/test-classes PhantomBuffReservationsTest

--- a/L2J_Mobius_CT_0_Interlude github/dist/game/config/Rates.ini
+++ b/L2J_Mobius_CT_0_Interlude github/dist/game/config/Rates.ini
@@ -29,6 +29,14 @@ RateSiegeGuardsPrice = 1
 # Default: 1.
 RateExtractable = 1.
 
+# Multiplier applied to fake-player private-store and crafter prices (custom "Living World" feature).
+# Prices are already derived from each item's NPC reference price, so this shifts the whole scale up or
+# down while keeping the relationships between items intact. Raise it to track an inflated adena rate
+# (e.g. 4 on a 4x adena server) so private-store prices feel appropriate. Editable live from the //rates
+# panel (Store Price row) or with "//setrate storeprice <value>"; takes effect on newly generated/restocked
+# stores (or after //reloadfakeplayers). Default: 1 (retail-like).
+FakePlayerStorePriceMultiplier = 1
+
 
 # ---------------------------------------------------------------------------
 # Quest Multipliers

--- a/L2J_Mobius_CT_0_Interlude github/dist/game/data/html/admin/rates.htm
+++ b/L2J_Mobius_CT_0_Interlude github/dist/game/data/html/admin/rates.htm
@@ -12,75 +12,87 @@
 <br><br>
 
 <table width=270 border=0>
-<tr><td width=90><font color="LEVEL">XP</font> (now: %xp%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate xp 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate xp 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="10x" action="bypass -h admin_setrate xp 10" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="20x" action="bypass -h admin_setrate xp 20" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<tr><td width=104><font color="LEVEL">XP</font> (%xp%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate xp 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate xp 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="10x" action="bypass -h admin_setrate xp 10" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="20x" action="bypass -h admin_setrate xp 20" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
-<tr><td width=90><font color="LEVEL">SP</font> (now: %sp%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate sp 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate sp 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="10x" action="bypass -h admin_setrate sp 10" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="20x" action="bypass -h admin_setrate sp 20" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<tr><td width=104><font color="LEVEL">SP</font> (%sp%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate sp 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate sp 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="10x" action="bypass -h admin_setrate sp 10" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="20x" action="bypass -h admin_setrate sp 20" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
-<tr><td width=90><font color="LEVEL">Party XP</font> (now: %partyxp%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate partyxp 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate partyxp 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="10x" action="bypass -h admin_setrate partyxp 10" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="20x" action="bypass -h admin_setrate partyxp 20" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-</tr>
-</table>
-
-<br>
-<table width=270 border=0>
-<tr><td width=90><font color="LEVEL">Adena</font> (now: %adena%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate adena 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate adena 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate adena 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="10x" action="bypass -h admin_setrate adena 10" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-</tr>
-<tr><td width=90><font color="LEVEL">Drop Amt</font> (now: %dropamount%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate dropamount 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate dropamount 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate dropamount 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate dropamount 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-</tr>
-<tr><td width=90><font color="LEVEL">Drop %</font> (now: %dropchance%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate dropchance 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate dropchance 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate dropchance 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate dropchance 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-</tr>
-<tr><td width=90><font color="LEVEL">Spoil</font> (now: %spoil%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate spoil 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate spoil 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate spoil 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate spoil 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-</tr>
-<tr><td width=90><font color="LEVEL">Raid Drop</font> (now: %raidrop%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate raidrop 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate raidrop 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate raidrop 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate raidrop 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<tr><td width=104><font color="LEVEL">Party XP</font> (%partyxp%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate partyxp 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate partyxp 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="10x" action="bypass -h admin_setrate partyxp 10" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="20x" action="bypass -h admin_setrate partyxp 20" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
 </table>
 
 <br>
 <table width=270 border=0>
-<tr><td width=90><font color="LEVEL">Quest XP</font> (now: %questxp%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate questxp 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate questxp 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate questxp 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate questxp 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<tr><td width=104><font color="LEVEL">Adena</font> (%adena%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate adena 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate adena 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate adena 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="10x" action="bypass -h admin_setrate adena 10" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
-<tr><td width=90><font color="LEVEL">Quest Adena</font> (now: %questadena%x)</td>
-<td><button value="1x" action="bypass -h admin_setrate questadena 1" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="2x" action="bypass -h admin_setrate questadena 2" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="3x" action="bypass -h admin_setrate questadena 3" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
-<td><button value="5x" action="bypass -h admin_setrate questadena 5" width=42 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<tr><td width=104><font color="LEVEL">Drop Amt</font> (%dropamount%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate dropamount 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate dropamount 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate dropamount 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate dropamount 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+<tr><td width=104><font color="LEVEL">Drop %</font> (%dropchance%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate dropchance 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate dropchance 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate dropchance 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate dropchance 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+<tr><td width=104><font color="LEVEL">Spoil</font> (%spoil%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate spoil 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate spoil 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate spoil 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate spoil 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+<tr><td width=104><font color="LEVEL">Raid Drop</font> (%raidrop%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate raidrop 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate raidrop 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate raidrop 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate raidrop 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
 </table>
+
+<br>
+<table width=270 border=0>
+<tr><td width=104><font color="LEVEL">Quest XP</font> (%questxp%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate questxp 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate questxp 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate questxp 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate questxp 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+<tr><td width=104><font color="LEVEL">Quest Adena</font> (%questadena%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate questadena 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate questadena 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="3x" action="bypass -h admin_setrate questadena 3" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="5x" action="bypass -h admin_setrate questadena 5" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+</table>
+
+<br>
+<font color="808080">Private-store &amp; crafter prices (match to your adena rate)</font>
+<table width=270 border=0>
+<tr><td width=104><font color="LEVEL">Store Price</font> (%storeprice%x)</td>
+<td><button value="1x" action="bypass -h admin_setrate storeprice 1" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="2x" action="bypass -h admin_setrate storeprice 2" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="4x" action="bypass -h admin_setrate storeprice 4" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+<td><button value="8x" action="bypass -h admin_setrate storeprice 8" width=38 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
+</tr>
+</table>
+<font color="606060">Applies to newly stocked shops (or after //reloadfakeplayers)</font>
 
 <br>
 <table width=270>
@@ -91,6 +103,6 @@
 <td><button value="Set" action="bypass -h admin_setrate $rkey $rval" width=45 height=21 back="L2UI_ch3.smallbutton2_over" fore="L2UI_ch3.smallbutton2"></td>
 </tr>
 </table>
-<font color="808080">Keys: xp sp partyxp partysp adena drop spoil raidrop questxp questsp questadena</font>
+<font color="808080">Keys: xp sp partyxp partysp adena drop spoil raidrop questxp questsp questadena storeprice</font>
 </center>
 </body></html>

--- a/L2J_Mobius_CT_0_Interlude github/dist/game/data/scripts/handlers/chat/commands/admin/AdminRates.java
+++ b/L2J_Mobius_CT_0_Interlude github/dist/game/data/scripts/handlers/chat/commands/admin/AdminRates.java
@@ -107,8 +107,11 @@ public class AdminRates implements IAdminCommandHandler
 				case "questadena":
 					RatesConfig.RATE_QUEST_REWARD_ADENA = Float.parseFloat(val);
 					break;
+				case "storeprice":
+					RatesConfig.RATE_FAKE_PLAYER_STORE_PRICE = Float.parseFloat(val);
+					break;
 				default:
-					activeChar.sendSysMessage("Unknown key: " + key + ". Valid keys: xp sp partyxp partysp adena drop dropamount dropchance spoil raidrop questxp questsp questadena");
+					activeChar.sendSysMessage("Unknown key: " + key + ". Valid keys: xp sp partyxp partysp adena drop dropamount dropchance spoil raidrop questxp questsp questadena storeprice");
 					return false;
 			}
 		}
@@ -144,6 +147,7 @@ public class AdminRates implements IAdminCommandHandler
 				else if (trimmed.startsWith("RateQuestRewardXP"))        line = "RateQuestRewardXP = " + RatesConfig.RATE_QUEST_REWARD_XP;
 				else if (trimmed.startsWith("RateQuestRewardSP"))        line = "RateQuestRewardSP = " + RatesConfig.RATE_QUEST_REWARD_SP;
 				else if (trimmed.startsWith("RateQuestRewardAdena"))     line = "RateQuestRewardAdena = " + RatesConfig.RATE_QUEST_REWARD_ADENA;
+				else if (trimmed.startsWith("FakePlayerStorePriceMultiplier")) line = "FakePlayerStorePriceMultiplier = " + RatesConfig.RATE_FAKE_PLAYER_STORE_PRICE;
 				else if (trimmed.startsWith("DropAmountMultiplierByItemId"))
 				{
 					// Rebuild the adena entry inline, preserve others
@@ -186,6 +190,7 @@ public class AdminRates implements IAdminCommandHandler
 		html.replace("%raidrop%",     fmt(RatesConfig.RATE_RAID_DROP_AMOUNT_MULTIPLIER));
 		html.replace("%questxp%",     fmt(RatesConfig.RATE_QUEST_REWARD_XP));
 		html.replace("%questadena%",  fmt(RatesConfig.RATE_QUEST_REWARD_ADENA));
+		html.replace("%storeprice%",  fmt(RatesConfig.RATE_FAKE_PLAYER_STORE_PRICE));
 		activeChar.sendPacket(html);
 	}
 

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
@@ -48,6 +48,9 @@ public class RatesConfig
 	public static float RATE_PARTY_XP;
 	public static float RATE_PARTY_SP;
 	public static float RATE_EXTRACTABLE;
+	// Custom: multiplier applied to fake-player private-store / crafter prices (see FakePlayerStoreFactory).
+	// 1 = retail-like reference prices; raise it to track an inflated adena rate (e.g. 4 on a 4x adena server).
+	public static float RATE_FAKE_PLAYER_STORE_PRICE;
 	public static int RATE_DROP_MANOR;
 	public static float QUEST_ITEM_DROP_AMOUNT_MULTIPLIER;
 	public static float RATE_QUEST_REWARD;
@@ -116,6 +119,7 @@ public class RatesConfig
 		RATE_PARTY_XP = config.getFloat("RatePartyXp", 1);
 		RATE_PARTY_SP = config.getFloat("RatePartySp", 1);
 		RATE_EXTRACTABLE = config.getFloat("RateExtractable", 1);
+		RATE_FAKE_PLAYER_STORE_PRICE = config.getFloat("FakePlayerStorePriceMultiplier", 1);
 		RATE_DROP_MANOR = config.getInt("RateDropManor", 1);
 		QUEST_ITEM_DROP_AMOUNT_MULTIPLIER = config.getFloat("QuestItemDropAmountMultiplier", 1);
 		RATE_QUEST_REWARD = config.getFloat("RateQuestReward", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStoreFactory.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStoreFactory.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.l2jmobius.commons.util.Rnd;
+import org.l2jmobius.gameserver.config.RatesConfig;
 import org.l2jmobius.gameserver.data.xml.ItemData;
 import org.l2jmobius.gameserver.data.xml.RecipeData;
 import org.l2jmobius.gameserver.model.actor.holders.npc.FakePlayerCraftItem;
@@ -44,7 +45,9 @@ import org.l2jmobius.gameserver.model.item.type.ItemType;
  * Everything is driven by the datapack item table, so prices and grades are the game's own:
  * <ul>
  * <li><b>Realistic pricing</b> - each line is {@link ItemTemplate#getReferencePrice()} times a small
- * markup (sellers ask above, buyers offer below). No hand-tuned price list to maintain.</li>
+ * markup (sellers ask above, buyers offer below). No hand-tuned price list to maintain. The whole scale is
+ * shifted by the live {@code FakePlayerStorePriceMultiplier} rate ({@link #effRef(int)}), so a server on an
+ * inflated adena rate can raise store prices to match with one knob without changing the relative prices.</li>
  * <li><b>Grade scarcity</b> - equipment is picked by a weighted grade roll (no-grade/D common, S
  * extremely rare) and additionally capped by the vendor's level, so a low-level town never floods with
  * S-grade and high grades stay scarce everywhere.</li>
@@ -384,7 +387,7 @@ public class FakePlayerStoreFactory
 		}
 
 		final int count = Rnd.get(SHOT_STACK_MIN, SHOT_STACK_MAX);
-		final int price = priced(item.getReferencePrice(), 1.0, 1.25);
+		final int price = priced(effRef(item.getReferencePrice()), 1.0, 1.25);
 		stock.add(line(item, 0, count, price));
 	}
 
@@ -479,7 +482,7 @@ public class FakePlayerStoreFactory
 		{
 			final int fallbackCount = item.isStackable() ? bulkAmount(item.getReferencePrice()) : 1;
 			final int count = normalizedDealCount(item, requestedCount, fallbackCount);
-			final int price = unitPrice > 0 ? clampDealPrice(unitPrice, item.getReferencePrice(), true) : priced(item.getReferencePrice(), 1.0, 1.6);
+			final int price = unitPrice > 0 ? clampDealPrice(unitPrice, effRef(item.getReferencePrice()), true) : priced(effRef(item.getReferencePrice()), 1.0, 1.6);
 			stock.add(line(item, 0, count, price));
 		}
 		return stock;
@@ -520,7 +523,7 @@ public class FakePlayerStoreFactory
 		{
 			final int fallbackCount = item.isStackable() ? bulkAmount(item.getReferencePrice()) : Rnd.get(1, 3);
 			final int count = normalizedDealCount(item, requestedCount, fallbackCount);
-			final int price = unitPrice > 0 ? clampDealPrice(unitPrice, item.getReferencePrice(), false) : priced(item.getReferencePrice(), 0.5, 0.85);
+			final int price = unitPrice > 0 ? clampDealPrice(unitPrice, effRef(item.getReferencePrice()), false) : priced(effRef(item.getReferencePrice()), 0.5, 0.85);
 			stock.add(line(item, 0, count, price));
 		}
 		return stock;
@@ -547,6 +550,17 @@ public class FakePlayerStoreFactory
 	private static int clampDealPrice(int unitPrice, int referencePrice, boolean selling)
 	{
 		return FakePlayerStorePricing.clampDealPrice(unitPrice, referencePrice, selling);
+	}
+
+	/**
+	 * The item reference price scaled by the live store-price multiplier ({@link RatesConfig#RATE_FAKE_PLAYER_STORE_PRICE}).
+	 * All store pricing derives from this so generated stores, negotiated deals and the anti-injection clamp band scale
+	 * together; stack sizes are unaffected (they use the raw reference). Read live so {@code //setrate storeprice} takes
+	 * effect on the next generated/restocked store without a restart.
+	 */
+	private static int effRef(int referencePrice)
+	{
+		return FakePlayerStorePricing.effectiveReference(referencePrice, RatesConfig.RATE_FAKE_PLAYER_STORE_PRICE);
 	}
 
 	/** referencePrice * random factor in [lo, hi], clamped to a valid positive int. */
@@ -595,7 +609,7 @@ public class FakePlayerStoreFactory
 			}
 			final int count = bulk ? bulkAmount(item.getReferencePrice()) : 1;
 			final int enchant = (!bulk && (item.getCrystalType().ordinal() >= 1) && (Rnd.get(100) < 15)) ? Rnd.get(1, 4) : 0;
-			final int price = priced(item.getReferencePrice(), bulk ? 1.0 : 1.0, bulk ? 1.4 : 1.7);
+			final int price = priced(effRef(item.getReferencePrice()), bulk ? 1.0 : 1.0, bulk ? 1.4 : 1.7);
 			stock.add(line(item, enchant, count, price));
 		}
 		return stock;
@@ -623,7 +637,7 @@ public class FakePlayerStoreFactory
 				continue;
 			}
 			final int count = bulk ? bulkAmount(item.getReferencePrice()) : Rnd.get(1, 3);
-			final int price = priced(item.getReferencePrice(), 0.45, 0.8);
+			final int price = priced(effRef(item.getReferencePrice()), 0.45, 0.8);
 			stock.add(line(item, 0, count, price));
 		}
 		return stock;
@@ -642,7 +656,7 @@ public class FakePlayerStoreFactory
 		if (item != null)
 		{
 			final int count = Rnd.get(ANCIENT_ADENA_SELL_STOCK_MIN, ANCIENT_ADENA_SELL_STOCK_MAX);
-			stock.add(line(item, 0, count, ANCIENT_ADENA_SELL_UNIT));
+			stock.add(line(item, 0, count, effRef(ANCIENT_ADENA_SELL_UNIT)));
 		}
 		return stock;
 	}
@@ -659,7 +673,7 @@ public class FakePlayerStoreFactory
 		if (item != null)
 		{
 			final int count = Rnd.get(ANCIENT_ADENA_BUY_STOCK_MIN, ANCIENT_ADENA_BUY_STOCK_MAX);
-			stock.add(line(item, 0, count, ANCIENT_ADENA_BUY_UNIT));
+			stock.add(line(item, 0, count, effRef(ANCIENT_ADENA_BUY_UNIT)));
 		}
 		return stock;
 	}
@@ -722,7 +736,7 @@ public class FakePlayerStoreFactory
 				continue;
 			}
 			final ItemTemplate product = ItemData.getInstance().getTemplate(recipe.getItemId());
-			final int productValue = product == null ? 1000 : product.getReferencePrice();
+			final int productValue = effRef(product == null ? 1000 : product.getReferencePrice());
 			final int fee = (int) Math.max(100L, Math.min((long) (productValue * (0.08 + (Rnd.nextDouble() * 0.17))), Integer.MAX_VALUE));
 			recipes.add(new FakePlayerCraftItem(recipe.getId(), fee));
 		}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java
@@ -44,6 +44,26 @@ public final class FakePlayerStorePricing
 	}
 
 	/**
+	 * Scales an item's reference price by the configurable store-price multiplier to yield the
+	 * <i>effective</i> reference used for all fake-player store pricing. Feeding this into the markup and
+	 * clamp logic keeps generated stores, negotiated deals and the anti-injection band all coherent, so a
+	 * server on an inflated adena rate can raise store prices to match with a single knob. A multiplier of
+	 * {@code <= 0} (or exactly 1) leaves the price unchanged; the result is clamped to {@code [1, Integer.MAX_VALUE]}.
+	 * @param referencePrice the item reference price
+	 * @param multiplier the store-price multiplier (retail-like = 1)
+	 * @return the scaled reference price, at least 1 and never overflowing an int
+	 */
+	public static int effectiveReference(int referencePrice, double multiplier)
+	{
+		if ((multiplier <= 0) || (multiplier == 1) || (referencePrice <= 0))
+		{
+			return Math.max(1, referencePrice);
+		}
+		final long scaled = Math.round(referencePrice * multiplier);
+		return (int) Math.max(1L, Math.min(scaled, Integer.MAX_VALUE));
+	}
+
+	/**
 	 * Clamp a whisper-negotiated unit price into a sane band around the item reference price. The agreed
 	 * price is trust-based on the LLM, so without this a player (or a trade-chat prompt injection) could talk
 	 * a bot into selling a rare item for 1 adena or buying junk for billions. Haggling still works within the

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuddyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuddyManager.java
@@ -1037,6 +1037,10 @@ public class PhantomBuddyManager implements IXmlReader
 				}
 				state.pendingBuff = null;
 				state.pendingBuffTarget = null;
+				if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), buddy.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+				{
+					return true; // a party support is already landing this exact buff on the target
+				}
 				buddy.setTarget(target);
 				buddy.doCast(buff);
 				return true;
@@ -1292,6 +1296,11 @@ public class PhantomBuddyManager implements IXmlReader
 				{
 					return true; // getting up first; recast this same buff next tick (index NOT advanced, so none is skipped)
 				}
+				if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), buddy.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+				{
+					state.rebuffIdx++; // a party support is already (re)casting this exact buff - skip so it isn't doubled
+					continue;
+				}
 				state.rebuffIdx++;
 				buddy.setTarget(target);
 				buddy.doCast(buff);
@@ -1315,6 +1324,10 @@ public class PhantomBuddyManager implements IXmlReader
 		{
 			return true; // getting up first; the buff lands next tick. Return "busy" so the caller doesn't fall
 			// through to the MP-rest and sit the buddy straight back down while it's trying to stand and buff.
+		}
+		if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), buddy.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+		{
+			return false; // a party support is already landing this exact buff on the target - skip it this tick
 		}
 		buddy.setTarget(target);
 		buddy.doCast(buff);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2013 L2jMobius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.l2jmobius.gameserver.managers;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Pure, game-type-free registry backing the cross-caster buff reservations used by {@link PhantomBuffs}.
+ * <p>
+ * Several independent bot buff sources can target the same player - the recruited-party supports
+ * ({@code PhantomPartyManager}) and the personal support buddy ({@code PhantomBuddyManager}). A cast is not
+ * instant, so if two of them both decide to cast the same buff inside the cast-time window, each sees "not
+ * buffed yet" and both cast, landing the buff twice (a double icon, and for some buffs a doubled stat). A caster
+ * claims a {@code (target, skill)} slot just before casting; another caster that finds it claimed by a
+ * <i>different</i> caster skips that buff. Claims carry an expiry so nothing needs an explicit release.
+ * <p>
+ * The time source and the composed key are passed in, so this is fully deterministic and unit-testable with a
+ * plain JDK (see {@code tests/java/PhantomBuffReservationsTest.java}); {@link PhantomBuffs} feeds it
+ * {@link System#currentTimeMillis()} and the real object ids. {@link ConcurrentHashMap#compute} makes each claim
+ * atomic, so simultaneous ticks on different threads can never both win the same slot.
+ */
+public final class PhantomBuffReservations
+{
+	// Key -> {expiryMillis, casterId}. Bounded by opportunistic pruning of expired entries.
+	private final ConcurrentHashMap<Long, long[]> _reservations = new ConcurrentHashMap<>();
+
+	// Above this many live entries, drop the expired ones so a long uptime can't grow the map without bound.
+	private static final int PRUNE_THRESHOLD = 1024;
+
+	/**
+	 * Composes the reservation key for a {@code (target, skill)} pair. Object ids and skill ids are ints, so they
+	 * pack losslessly into the high/low halves of a long.
+	 * @param targetObjectId the buff target's object id
+	 * @param skillId the buff skill id
+	 * @return a unique key for this target/skill pair
+	 */
+	public static long key(int targetObjectId, int skillId)
+	{
+		return ((long) targetObjectId << 32) | (skillId & 0xFFFFFFFFL);
+	}
+
+	/**
+	 * Attempts to claim a slot. A slot is granted when it is free, expired, or already held by this same caster
+	 * (a re-claim just refreshes it); it is refused only while a <i>different</i> caster holds an unexpired claim.
+	 * @param key the {@link #key(int, int)} of the target/skill pair
+	 * @param nowMillis the current time
+	 * @param casterId the claiming caster's id
+	 * @param holdMillis how long the claim is held from {@code nowMillis}
+	 * @return {@code true} if the caster may cast now; {@code false} if a different caster is already holding it
+	 */
+	public boolean reserve(long key, long nowMillis, int casterId, int holdMillis)
+	{
+		final boolean[] granted =
+		{
+			false
+		};
+		_reservations.compute(key, (k, cur) ->
+		{
+			if ((cur != null) && (cur[0] > nowMillis) && (cur[1] != casterId))
+			{
+				granted[0] = false;
+				return cur; // still held by a different caster
+			}
+			granted[0] = true;
+			return new long[]
+			{
+				nowMillis + holdMillis,
+				casterId
+			};
+		});
+		if (_reservations.size() > PRUNE_THRESHOLD)
+		{
+			_reservations.values().removeIf(v -> v[0] <= nowMillis);
+		}
+		return granted[0];
+	}
+
+	/** @return the number of live entries (test/diagnostic use). */
+	public int size()
+	{
+		return _reservations.size();
+	}
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffs.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffs.java
@@ -289,4 +289,34 @@ public final class PhantomBuffs
 			}
 		}
 	}
+
+	// ===== Cross-caster buff reservations =====
+	// Several independent bot buff sources can target the same player: the recruited-party supports
+	// (PhantomPartyManager) and the personal support buddy (PhantomBuddyManager). A cast is not instant, so if two
+	// of them both decide to cast the SAME buff inside the cast-time window, each sees "target not buffed yet" and
+	// both cast, landing the buff twice (a double icon, and for some buffs a doubled stat). The shared, race-safe
+	// PhantomBuffReservations registry makes the sources coordinate: a caster claims (target, skill) just before
+	// casting; anyone else who finds it claimed by a different caster skips that buff. Claims auto-expire.
+	private static final PhantomBuffReservations BUFF_RESERVATIONS = new PhantomBuffReservations();
+
+	/**
+	 * Attempts to claim a buff cast so no other bot double-casts the same buff on the same target. Call this
+	 * immediately before {@code doCast}, once every other gate (range / MP / stand-up) has passed.
+	 * @param targetObjectId the buff target's object id
+	 * @param skillId the buff skill id
+	 * @param casterObjectId the casting phantom's object id (a caster never blocks its own re-claim)
+	 * @param holdMillis how long the claim is held (use {@link #buffHoldMillis(Skill)})
+	 * @return {@code true} if this caster may cast now (claim taken/refreshed); {@code false} if a different bot is
+	 *         already landing this exact buff on this target and the caller should skip it
+	 */
+	public static boolean reserveBuff(int targetObjectId, int skillId, int casterObjectId, int holdMillis)
+	{
+		return BUFF_RESERVATIONS.reserve(PhantomBuffReservations.key(targetObjectId, skillId), System.currentTimeMillis(), casterObjectId, holdMillis);
+	}
+
+	/** How long to hold a buff reservation: the skill's cast time plus a margin for the effect to actually land. */
+	public static int buffHoldMillis(Skill buff)
+	{
+		return Math.max(2500, buff.getHitTime() + 1200);
+	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -3232,6 +3232,10 @@ public class PhantomPartyManager
 				}
 				state.pendingBuff = null;
 				state.pendingBuffTarget = null;
+				if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), npc.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+				{
+					return; // another support (or the buddy) is already landing this exact buff on the target
+				}
 				npc.setTarget(target);
 				npc.doCast(buff);
 				return;
@@ -4017,6 +4021,11 @@ public class PhantomPartyManager
 					{
 						return true; // getting up first; cast this same buff next tick (index NOT advanced, so it isn't skipped)
 					}
+					if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), npc.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+					{
+						state.rebuffIdx++; // another support (or the buddy) is already (re)casting this exact buff - skip so it isn't doubled
+						continue;
+					}
 					state.rebuffIdx++;
 					npc.setTarget(target);
 					npc.doCast(buff);
@@ -4057,6 +4066,10 @@ public class PhantomPartyManager
 				if (!readyToCast(npc))
 				{
 					return true; // getting up first; cast on the next tick
+				}
+				if (!PhantomBuffs.reserveBuff(target.getObjectId(), buff.getId(), npc.getObjectId(), PhantomBuffs.buffHoldMillis(buff)))
+				{
+					continue; // another bot buffer (party support or the personal buddy) is already landing this exact buff
 				}
 				npc.setTarget(target);
 				npc.doCast(buff);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/network/clientpackets/RequestBuyItem.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/network/clientpackets/RequestBuyItem.java
@@ -48,6 +48,10 @@ public class RequestBuyItem extends ClientPacket
 {
 	private static final int BATCH_LENGTH = 8;
 	private static final int CUSTOM_CB_SELL_LIST = 423;
+	// Retail anti-abuse cap on how many of a single item may be bought in one buylist transaction.
+	// Enforced for regular players only; GMs are exempt so the //admin GM shop can hand out large
+	// stacks of currency/consumables (e.g. buying a million adena) without hitting this limit.
+	private static final int MAX_ITEM_COUNT_PER_TRANSACTION = 10000;
 	
 	private int _listId;
 	private List<ItemHolder> _items = null;
@@ -72,13 +76,9 @@ public class RequestBuyItem extends ClientPacket
 				_items = null;
 				return;
 			}
-			
-			if (count > 10000) // Count check.
-			{
-				_items = null;
-				return;
-			}
-			
+
+			// The per-item count cap is enforced in runImpl(), where the buyer's GM status is known, so a GM
+			// can purchase large stacks (e.g. currency from the //admin GM shop) that a regular player cannot.
 			_items.add(new ItemHolder(itemId, count));
 		}
 	}
@@ -100,7 +100,6 @@ public class RequestBuyItem extends ClientPacket
 		
 		if (_items == null)
 		{
-			player.sendMessage("You cannot buy more than 10.000 items.");
 			player.sendPacket(ActionFailed.STATIC_PACKET);
 			return;
 		}
@@ -167,7 +166,16 @@ public class RequestBuyItem extends ClientPacket
 		for (ItemHolder i : _items)
 		{
 			int price = -1;
-			
+
+			// Retail per-item transaction cap - regular players only. GMs are exempt so the //admin GM shop
+			// can dispense large stacks (currency, consumables); GMs already bypass the weight/slot checks below.
+			if (!player.isGM() && (i.getCount() > MAX_ITEM_COUNT_PER_TRANSACTION))
+			{
+				player.sendMessage("You cannot buy more than " + MAX_ITEM_COUNT_PER_TRANSACTION + " items at a time.");
+				player.sendPacket(ActionFailed.STATIC_PACKET);
+				return;
+			}
+
 			final Product product = buyList.getProductByItemId(i.getId());
 			if (product == null)
 			{

--- a/L2J_Mobius_CT_0_Interlude github/tests/java/FakePlayerStorePricingTest.java
+++ b/L2J_Mobius_CT_0_Interlude github/tests/java/FakePlayerStorePricingTest.java
@@ -46,6 +46,7 @@ public class FakePlayerStorePricingTest
 
 	public static void main(String[] args)
 	{
+		testEffectiveReference();
 		testClampDealPrice();
 		testNormalizedDealCount();
 		testBulkAmountRange();
@@ -61,6 +62,23 @@ public class FakePlayerStorePricingTest
 			System.exit(1);
 		}
 		System.out.println("OK");
+	}
+
+	private static void testEffectiveReference()
+	{
+		// Multiplier of 1 (or the price already <= 0) is an identity: today's retail-like behaviour is unchanged.
+		eq(1000, FakePlayerStorePricing.effectiveReference(1000, 1.0), "1x multiplier leaves the price unchanged");
+		eq(1, FakePlayerStorePricing.effectiveReference(0, 4.0), "zero reference price -> at least 1");
+		// A raised multiplier scales the whole reference up (this is the //rates 'storeprice' knob).
+		eq(4000, FakePlayerStorePricing.effectiveReference(1000, 4.0), "4x multiplier scales the reference");
+		eq(2500, FakePlayerStorePricing.effectiveReference(1000, 2.5), "fractional multiplier scales the reference");
+		eq(333, FakePlayerStorePricing.effectiveReference(1000, 0.333), "sub-1 multiplier discounts (rounded)");
+		eq(3, FakePlayerStorePricing.effectiveReference(10, 0.25), "rounding: 10 * 0.25 -> 3 (round half up)");
+		// A non-positive multiplier is treated as 1 so a mis-set config can never zero out or invert prices.
+		eq(1000, FakePlayerStorePricing.effectiveReference(1000, 0.0), "zero multiplier treated as 1x");
+		eq(1000, FakePlayerStorePricing.effectiveReference(1000, -3.0), "negative multiplier treated as 1x");
+		// A huge multiplier can never overflow the int the store line stores.
+		eq(Integer.MAX_VALUE, FakePlayerStorePricing.effectiveReference(200_000_000, 1000.0), "overflow clamped to Integer.MAX_VALUE");
 	}
 
 	private static void testClampDealPrice()

--- a/L2J_Mobius_CT_0_Interlude github/tests/java/PhantomBuffReservationsTest.java
+++ b/L2J_Mobius_CT_0_Interlude github/tests/java/PhantomBuffReservationsTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2013 L2jMobius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import org.l2jmobius.gameserver.managers.PhantomBuffReservations;
+
+/**
+ * Standalone (no JUnit, no game server) regression harness for {@link PhantomBuffReservations} - the shared,
+ * race-safe registry that stops two independent bot buff sources (a recruited-party support and the personal
+ * buddy) from double-casting the same buff on the same target. The time source and key are injected, so the
+ * expiry / caster-identity logic is verified deterministically.
+ *
+ * <p>Run from the project root ("L2J_Mobius_CT_0_Interlude github"):
+ * <pre>
+ *   javac -d build/test-classes \
+ *         "java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java" \
+ *         "tests/java/PhantomBuffReservationsTest.java"
+ *   java -cp build/test-classes PhantomBuffReservationsTest
+ * </pre>
+ * Exit code is 0 when every check passes, 1 otherwise.
+ */
+public class PhantomBuffReservationsTest
+{
+	private static int checks = 0;
+	private static int failures = 0;
+
+	// Distinct object ids for readability.
+	private static final int TARGET = 100;
+	private static final int OTHER_TARGET = 200;
+	private static final int PROPHET = 10;
+	private static final int BUDDY = 11;
+	private static final int MIGHT = 1068;
+	private static final int SHIELD = 1040;
+	private static final int HOLD = 3000;
+
+	public static void main(String[] args)
+	{
+		testGrantAndBlock();
+		testSameCasterRefresh();
+		testExpiry();
+		testIndependentSlots();
+		testKeyUniqueness();
+
+		System.out.println();
+		System.out.println("Ran " + checks + " checks, " + failures + " failure(s).");
+		if (failures > 0)
+		{
+			System.exit(1);
+		}
+		System.out.println("OK");
+	}
+
+	/** First caster wins the slot; a different caster is refused while it is held. */
+	private static void testGrantAndBlock()
+	{
+		final PhantomBuffReservations r = new PhantomBuffReservations();
+		final long key = PhantomBuffReservations.key(TARGET, MIGHT);
+		eq(true, r.reserve(key, 1000, PROPHET, HOLD), "first caster claims the slot");
+		eq(false, r.reserve(key, 1500, BUDDY, HOLD), "a different caster is refused while the claim is live");
+		eq(false, r.reserve(key, 3999, BUDDY, HOLD), "still refused just before expiry");
+	}
+
+	/** The holder re-claiming its own slot always succeeds (a support re-casting the same buff refreshes, never blocks itself). */
+	private static void testSameCasterRefresh()
+	{
+		final PhantomBuffReservations r = new PhantomBuffReservations();
+		final long key = PhantomBuffReservations.key(TARGET, MIGHT);
+		eq(true, r.reserve(key, 1000, PROPHET, HOLD), "claim");
+		eq(true, r.reserve(key, 1200, PROPHET, HOLD), "same caster re-claims (refresh, not blocked)");
+		// The refresh moved expiry to 1200+HOLD, so another caster stays blocked past the original 4000 expiry.
+		eq(false, r.reserve(key, 4100, BUDDY, HOLD), "refresh extended the hold, other caster still blocked");
+	}
+
+	/** Once a claim expires, another caster may take the slot. */
+	private static void testExpiry()
+	{
+		final PhantomBuffReservations r = new PhantomBuffReservations();
+		final long key = PhantomBuffReservations.key(TARGET, MIGHT);
+		eq(true, r.reserve(key, 1000, PROPHET, HOLD), "claim held until 4000");
+		eq(true, r.reserve(key, 4000, BUDDY, HOLD), "at expiry (exclusive) the slot is free again");
+	}
+
+	/** Different target/skill pairs are independent - claiming one never blocks another. */
+	private static void testIndependentSlots()
+	{
+		final PhantomBuffReservations r = new PhantomBuffReservations();
+		eq(true, r.reserve(PhantomBuffReservations.key(TARGET, MIGHT), 1000, PROPHET, HOLD), "claim Might on target");
+		eq(true, r.reserve(PhantomBuffReservations.key(TARGET, SHIELD), 1000, BUDDY, HOLD), "different skill on same target is free");
+		eq(true, r.reserve(PhantomBuffReservations.key(OTHER_TARGET, MIGHT), 1000, BUDDY, HOLD), "same skill on a different target is free");
+	}
+
+	/** The composed key must be unique per (target, skill) pair. */
+	private static void testKeyUniqueness()
+	{
+		final long tMight = PhantomBuffReservations.key(TARGET, MIGHT);
+		neq(tMight, PhantomBuffReservations.key(TARGET, SHIELD), "same target, different skill -> different key");
+		neq(tMight, PhantomBuffReservations.key(OTHER_TARGET, MIGHT), "different target, same skill -> different key");
+		eq(tMight, PhantomBuffReservations.key(TARGET, MIGHT), "same pair -> same key");
+	}
+
+	// ===== tiny assertion helpers =====
+
+	private static void eq(Object expected, Object actual, String what)
+	{
+		checks++;
+		if ((expected == null) ? (actual != null) : !expected.equals(actual))
+		{
+			failures++;
+			System.out.println("FAIL: " + what + " -> expected [" + expected + "] but got [" + actual + "]");
+		}
+	}
+
+	private static void neq(long a, long b, String what)
+	{
+		checks++;
+		if (a == b)
+		{
+			failures++;
+			System.out.println("FAIL: " + what + " -> both were [" + a + "]");
+		}
+	}
+}

--- a/L2J_Mobius_CT_0_Interlude github/tests/run_all.sh
+++ b/L2J_Mobius_CT_0_Interlude github/tests/run_all.sh
@@ -35,11 +35,13 @@ PROD_SOURCES=(
 	"java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java"
 	"java/org/l2jmobius/gameserver/managers/FakePlayerStorePricing.java"
 	"java/org/l2jmobius/gameserver/managers/FakePlayerNameFactory.java"
+	"java/org/l2jmobius/gameserver/managers/PhantomBuffReservations.java"
 )
 JAVA_MAIN_CLASSES=(
 	"FakePlayerChatParsingTest"
 	"FakePlayerStorePricingTest"
 	"FakePlayerNameFactoryTest"
+	"PhantomBuffReservationsTest"
 )
 
 failures=0


### PR DESCRIPTION
v0.1.5 released

1. Private stores & crafters now price consistently. Every shop/crafter price is based on the item's real in-game value, so grades line up sensibly (no more a D-grade piece costing more than the same B-grade one). New admin knob to scale all store prices to 
match your server's adena rate (e.g. 4× prices on a 4× adena server) via the //rates panel or //setrate storeprice <x>.

2. GM shop can now hand out large amounts of currency. Buying big stacks (like a million adena) from the //admin GM shop no longer errors out with "cannot buy more than 10.000 items." Normal players still have the usual limit.

3. Fixed bot buffs appearing twice. Support bots (party buffers and your personal buddy) sometimes double-cast the same buff, showing duplicate icons (and occasionally doubling the effect). They now coordinate, so each buff lands exactly once, even with two buffers or on a "rebuff" command.
