### PR TITLE
Add incremental patch zip to the release build

### DIFF
--- a/.github/workflows/build-oneclick-pack.yml
+++ b/.github/workflows/build-oneclick-pack.yml
@@ -60,3 +60,14 @@ jobs:
           path: "L2J_Mobius_CT_0_Interlude github/L2J-Offline-OneClick.zip"
           if-no-files-found: error
           retention-days: 30
+
+      # The incremental patch zip (built from dist/launcher/patch-manifest.txt) for
+      # existing testers to update without losing their database. Warn (don't fail)
+      # if it is absent, so the full-pack build still succeeds when no manifest exists.
+      - name: Upload the patch zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: L2J-Offline-Patch
+          path: "L2J_Mobius_CT_0_Interlude github/L2J-Offline-Patch.zip"
+          if-no-files-found: warn
+          retention-days: 30

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/README.md
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/README.md
@@ -60,6 +60,28 @@ the servers and the bundled DB down cleanly.
 
 ---
 
+## Updating an existing install (patch zip)
+
+Alongside the full `L2J-Offline-OneClick.zip`, the build also produces a small **`L2J-Offline-Patch.zip`**
+containing only the files that changed this release (`libs\GameServer.jar` plus whatever is listed in
+`patch-manifest.txt`). It exists so a tester who already has the pack installed can update **without
+losing their database**:
+
+1. `Stop-Server.bat`.
+2. Unzip `L2J-Offline-Patch.zip` **over** the existing install folder, overwriting when asked.
+3. `Start-Server.bat`.
+
+The patch carries no `mariadb\` folder, so the player's database (characters, items, adena) is never
+touched. It also deliberately excludes configs a player may have customized (e.g. `Rates.ini`) — new
+config keys are called out in the release notes instead.
+
+**Per release:** edit `dist/launcher/patch-manifest.txt` — clear last release's entries and list the
+datapack/config/html files that changed this time (one path per line, relative to the pack root; the
+jar is auto-included). The build **fails** if a listed file isn't in the pack, so a typo can't ship a
+broken patch. No manifest → the patch step is skipped and only the full pack is produced.
+
+---
+
 ## What the launcher does, in order
 
 1. **Pre-flight** — one screen listing anything missing (Java / DB engine / jars) before it starts.

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/build-pack.ps1
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/build-pack.ps1
@@ -220,7 +220,71 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 [System.IO.Compression.ZipFile]::CreateFromDirectory($Pack, $outZip, [System.IO.Compression.CompressionLevel]::Optimal, $false)
 $sizeMb = [math]::Round((Get-Item $outZip).Length / 1MB, 1)
 Ok "DONE -> $outZip  ($sizeMb MB)"
+
+# ---- 8. build the incremental patch zip -----------------------------------
+# A tiny companion zip holding ONLY the files that changed this release, for
+# testers who already installed the full pack: they unzip it OVER their install
+# to update without touching their database. The file list lives in
+# patch-manifest.txt (paths relative to the pack root); libs\GameServer.jar is
+# always included, since any code change rebuilds it. No manifest => no patch.
+$manifestPath = Join-Path $LauncherDir 'patch-manifest.txt'
+if (Test-Path $manifestPath) {
+    Info "building incremental patch zip from patch-manifest.txt ..."
+    $patchRoot = Join-Path $Staging 'patch'
+    New-Item -ItemType Directory -Path $patchRoot -Force | Out-Null
+
+    # The freshly built server jar is always part of a patch.
+    $entries = @('libs\GameServer.jar')
+    foreach ($line in (Get-Content $manifestPath)) {
+        $rel = $line.Trim()
+        if ($rel -eq '' -or $rel.StartsWith('#')) { continue }
+        $entries += ($rel -replace '/', '\')   # accept either slash style in the manifest
+    }
+
+    $missing = @()
+    foreach ($rel in ($entries | Select-Object -Unique)) {
+        $src = Join-Path $Pack $rel
+        if (-not (Test-Path $src)) { $missing += $rel; continue }
+        $dst = Join-Path $patchRoot $rel
+        New-Item -ItemType Directory -Path (Split-Path -Parent $dst) -Force | Out-Null
+        Copy-Item -Path $src -Destination $dst -Force
+    }
+    # Fail loudly rather than silently shipping an incomplete patch.
+    if ($missing.Count -gt 0) { Die ("patch-manifest.txt lists files not present in the built pack:`n  " + ($missing -join "`n  ")) }
+
+    $readme = @"
+L2 Living Worlds - update patch
+===============================
+
+This zip contains ONLY the files that changed in this release. It updates an
+EXISTING install WITHOUT touching your database (characters, items, adena).
+
+How to apply:
+  1. Stop the server if it is running (Stop-Server.bat).
+  2. Copy the folders inside this zip into your existing server folder and let
+     them overwrite when asked. The layout matches, so files land in the right
+     place.
+  3. Start the server again (Start-Server.bat).
+
+Your 'mariadb' folder is NOT in this zip, so your database is never overwritten.
+This patch also leaves config files you may have customized (e.g. your rates)
+alone - any new settings this release adds are called out in the release notes.
+"@
+    Set-Content -Path (Join-Path $patchRoot 'PATCH-README.txt') -Value $readme -Encoding ASCII
+
+    $patchZip = Join-Path $OutDir 'L2J-Offline-Patch.zip'
+    if (Test-Path $patchZip) { Remove-Item $patchZip -Force }
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($patchRoot, $patchZip, [System.IO.Compression.CompressionLevel]::Optimal, $false)
+    $patchMb = [math]::Round((Get-Item $patchZip).Length / 1MB, 2)
+    Ok "PATCH -> $patchZip  ($patchMb MB)"
+} else {
+    Info "no patch-manifest.txt found next to build-pack.ps1 - skipping the incremental patch zip."
+}
+
 Write-Host ""
-Write-Host "Copy that zip to the test VM, unzip anywhere, and double-click Start-Server.bat." -ForegroundColor Green
+Write-Host "Full pack : unzip anywhere and double-click Start-Server.bat (new testers)." -ForegroundColor Green
+if (Test-Path (Join-Path $OutDir 'L2J-Offline-Patch.zip')) {
+    Write-Host "Patch zip : existing testers unzip OVER their install to update, keeping their DB." -ForegroundColor Green
+}
 Write-Host "Cleaning staging..." -ForegroundColor Gray
 Remove-Item -Path $Staging -Recurse -Force -ErrorAction SilentlyContinue

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
@@ -1,0 +1,21 @@
+# Incremental patch manifest
+# ---------------------------------------------------------------------------
+# One path per line, RELATIVE TO THE PACK ROOT (i.e. the folder that has
+# game\, login\, libs\, launcher\, ...). These are the files that changed in
+# THIS release and should ship in L2J-Offline-Patch.zip so an existing tester
+# can unzip it over their install to update without touching their database.
+#
+# Rules:
+#   - libs\GameServer.jar is ALWAYS included automatically - do NOT list it.
+#   - Blank lines and lines starting with # are ignored.
+#   - Forward or back slashes are both fine.
+#   - Do NOT list files a tester may have customized (e.g. game\config\*.ini,
+#     especially Rates.ini) - overwriting those would reset their settings.
+#     Mention any new config keys in the release notes instead.
+#   - Edit this list for each release: remove last release's entries, add the
+#     datapack/config/html files that changed this time. The build FAILS if a
+#     listed file is missing from the pack, so a typo can't ship a broken patch.
+#
+# ---- current release -------------------------------------------------------
+game/data/html/admin/rates.htm
+game/data/scripts/handlers/chat/commands/admin/AdminRates.java


### PR DESCRIPTION
The one-click pack ships a mariadb\data folder at the same path the live DB uses, so copy-pasting a new full pack over an existing install wipes a tester's characters. build-pack.ps1 now also produces a small L2J-Offline-Patch.zip containing only the changed files (libs\GameServer.jar plus whatever patch-manifest.txt lists) and no mariadb\ folder, so an existing tester unzips it over their install and keeps their database.

- build-pack.ps1: new section reads patch-manifest.txt, copies the listed files + the jar into a patch tree, adds a PATCH-README, and zips it; fails loudly if a listed file is missing.
- patch-manifest.txt: curated per release; jar auto-included; excludes customizable configs (e.g. Rates.ini). Seeded with rates.htm + AdminRates.java.
- build-oneclick-pack.yml: uploads L2J-Offline-Patch as a second artifact.
- launcher README: documents the update flow and per-release manifest edit.