### PR TITLE
Fake Player/Phantoms fixes

### DIFF
--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/data/holders/ArmorSet.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/data/holders/ArmorSet.java
@@ -238,7 +238,32 @@ public class ArmorSet
 	{
 		return _chestId;
 	}
-	
+
+	public List<Integer> getLegs()
+	{
+		return _legs;
+	}
+
+	public List<Integer> getHead()
+	{
+		return _head;
+	}
+
+	public List<Integer> getGloves()
+	{
+		return _gloves;
+	}
+
+	public List<Integer> getFeet()
+	{
+		return _feet;
+	}
+
+	public List<Integer> getShieldIds()
+	{
+		return _shield;
+	}
+
 	public List<SkillHolder> getSkills()
 	{
 		return _skills;

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerAppearanceFactory.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerAppearanceFactory.java
@@ -20,102 +20,180 @@
  */
 package org.l2jmobius.gameserver.managers;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import org.l2jmobius.commons.util.Rnd;
+import org.l2jmobius.gameserver.data.xml.ItemData;
 import org.l2jmobius.gameserver.model.actor.enums.creature.Race;
 import org.l2jmobius.gameserver.model.actor.enums.player.PlayerClass;
 import org.l2jmobius.gameserver.model.actor.holders.npc.FakePlayerAppearance;
+import org.l2jmobius.gameserver.model.item.Armor;
+import org.l2jmobius.gameserver.model.item.ItemTemplate;
+import org.l2jmobius.gameserver.model.item.Weapon;
+import org.l2jmobius.gameserver.model.item.enums.BodyPart;
+import org.l2jmobius.gameserver.model.item.type.ArmorType;
+import org.l2jmobius.gameserver.model.item.type.CrystalType;
 
 /**
  * Procedurally generates {@link FakePlayerAppearance}s: unique pronounceable names plus a random but
- * coherent race / gender / class / look. Gear slots are intentionally left empty for now (wiring in
- * verified Interlude item display ids is a separate, data-driven step) but the appearance object
- * already supports them via {@code setArmor}/{@code setWeapon}.
+ * coherent race / gender / class / look. Gear is resolved data-driven from the item table by armor family
+ * and grade (no hard-coded id lists): a mystic gets a robe set + magic weapon, a fighter a light or heavy
+ * set + a sword/blunt, and every bot wears a <b>complete</b> set for its grade (chest + legs - or a single
+ * full-body piece - plus gloves and boots; only the helmet varies), so the crowd no longer shows random
+ * missing pieces or casters in plate.
  */
 public class FakePlayerAppearanceFactory
 {
-	// First-occupation (root) class ids per race for Interlude.
-	private static final int[] HUMAN_CLASSES =
+	// Occupation classes per race, split by level tier: [0] base (<20), [1] first occupation (20-39),
+	// [2] second occupation (40+). A generated bot draws a class from the tier its rolled level fits, so a town
+	// crowd shows recognizable knights / archers / daggers / healers / mages at the right levels instead of only
+	// base fighters and mystics. (Third-occupation classes, 76+, keep their 2nd-class look - fine visually.)
+	private static final int[][] HUMAN_TIERS =
 	{
-		0, // Human Fighter
-		10 // Human Mystic (Mage)
+		{
+			0,
+			10
+		}, // Fighter, Mage
+		{
+			1,
+			4,
+			7,
+			11,
+			15
+		}, // Warrior, Knight, Rogue, Wizard, Cleric
+		{
+			2,
+			3,
+			5,
+			6,
+			8,
+			9,
+			12,
+			13,
+			14,
+			16,
+			17
+		} // Gladiator, Warlord, Paladin, Dark Avenger, Treasure Hunter, Hawkeye, Sorcerer, Necromancer, Warlock, Bishop, Prophet
 	};
-	private static final int[] ELF_CLASSES =
+	private static final int[][] ELF_TIERS =
 	{
-		18, // Elven Fighter
-		25 // Elven Mystic
+		{
+			18,
+			25
+		},
+		{
+			19,
+			22,
+			26,
+			29
+		}, // Elven Knight, Elven Scout, Elven Wizard, Elven Oracle
+		{
+			20,
+			21,
+			23,
+			24,
+			27,
+			28,
+			30
+		} // Temple Knight, Swordsinger, Plains Walker, Silver Ranger, Spellsinger, Elemental Summoner, Elven Elder
 	};
-	private static final int[] DARK_ELF_CLASSES =
+	private static final int[][] DARK_ELF_TIERS =
 	{
-		31, // Dark Fighter
-		38 // Dark Mystic
+		{
+			31,
+			38
+		},
+		{
+			32,
+			35,
+			39,
+			42
+		}, // Palus Knight, Assassin, Dark Wizard, Shillien Oracle
+		{
+			33,
+			34,
+			36,
+			37,
+			40,
+			41,
+			43
+		} // Shillien Knight, Bladedancer, Abyss Walker, Phantom Ranger, Spellhowler, Phantom Summoner, Shillien Elder
 	};
-	private static final int[] ORC_CLASSES =
+	private static final int[][] ORC_TIERS =
 	{
-		44, // Orc Fighter
-		49 // Orc Mystic
+		{
+			44,
+			49
+		},
+		{
+			45,
+			47,
+			50
+		}, // Orc Raider, Orc Monk, Orc Shaman
+		{
+			46,
+			48,
+			51,
+			52
+		} // Destroyer, Tyrant, Overlord, Warcryer
 	};
-	private static final int[] DWARF_CLASSES =
+	private static final int[][] DWARF_TIERS =
 	{
-		53 // Dwarven Fighter
+		{
+			53
+		},
+		{
+			54,
+			56
+		}, // Scavenger, Artisan
+		{
+			55,
+			57
+		} // Bounty Hunter, Warsmith
 	};
 
-	// ===== Curated gear sets (verified item ids from the datapack), tiered by level. =====
-	// Weapons.
-	private static final int[] NG_FIGHTER_WEAPONS =
+	// ===== Data-driven display-gear pools, resolved once from the item table (no hard-coded id lists). =====
+	// Body slots that belong to an armor family (light/heavy/robe). FULL_ARMOR is a one-piece body armor (fills the
+	// chest slot; legs stay empty by design - not a "missing pants" bug).
+	private static final BodyPart[] BODY_SLOTS =
 	{
-		1, 2, 5, 12, 68, 159 // Short/Long Sword, Mace, Knife, Falchion, Bonebreaker
+		BodyPart.FULL_ARMOR,
+		BodyPart.CHEST,
+		BodyPart.LEGS
 	};
-	private static final int[] NG_MAGE_WEAPONS =
+	// Gloves / boots / helmet are family-agnostic (ArmorType.NONE - any class wears any of them), so they come from
+	// one shared pool per slot, not from the light/heavy/robe family pools.
+	private static final BodyPart[] EXTREMITY_SLOTS =
 	{
-		6, 8, 747 // Apprentice's Wand, Willow Staff, Wand of Adept
+		BodyPart.GLOVES,
+		BodyPart.FEET,
+		BodyPart.HEAD
 	};
-	private static final int[] D_FIGHTER_WEAPONS =
+	// The weapon look each archetype carries. SWORD_1H is a one-handed sword/blunt (so a shield fits) for
+	// tanks and swordsingers; SWORD is any sword/blunt for generic fighters.
+	private enum WeaponKind
 	{
-		129, 125, 127, 268, 72 // Sword of Revolution, Spinebone, Crimson, Bellion Cestus, Stormbringer
-	};
-	private static final int[] D_MAGE_WEAPONS =
-	{
-		189, 200, 195 // Staff of Life, Sage's Staff, Cursed Staff
-	};
-	private static final int[] C_FIGHTER_WEAPONS =
-	{
-		171, 75, 84 // Deadman's Glory, Caliburs, Homunkulus's Sword
-	};
-	private static final int[] C_MAGE_WEAPONS =
-	{
-		2373, 200 // Eldritch Staff, Sage's Staff
-	};
-
-	// Armor: {chest options} plus single legs/head/gloves/feet per tier.
-	private static final int[] NG_CHEST =
-	{
-		22, 1101, 352 // Leather Shirt, Tunic of Devotion, Brigandine Tunic
-	};
-	private static final int NG_LEGS = 29; // Leather Pants
-	private static final int NG_HEAD = 43; // Wooden Helmet
-	private static final int NG_GLOVES = 50; // Leather Gloves
-	private static final int NG_FEET = 37; // Leather Shoes
-
-	private static final int[] D_CHEST =
-	{
-		400, 356 // Theca Leather Armor, Full Plate Armor
-	};
-	private static final int[] D_LEGS =
-	{
-		417, 380 // Manticore Skin Gaiters, Plate Gaiters
-	};
-	private static final int D_HEAD = 2411; // Brigandine Helmet
-	private static final int D_FEET = 2425; // Brigandine Boots
-
-	private static final int[] C_CHEST =
-	{
-		437 // Mithril Tunic
-	};
-	private static final int C_LEGS = 59; // Mithril Gaiters
-	private static final int C_HEAD = 2412; // Plate Helmet
-	private static final int C_FEET = 2428; // Plate Boots
+		MAGIC,
+		SWORD,
+		SWORD_1H,
+		DAGGER,
+		BOW,
+		DUAL,
+		FIST
+	}
+	// family (LIGHT/HEAVY/MAGIC) -> grade -> body slot -> candidate display ids.
+	private static final Map<ArmorType, EnumMap<CrystalType, EnumMap<BodyPart, List<Integer>>>> ARMOR_POOLS = new EnumMap<>(ArmorType.class);
+	// grade -> extremity slot (gloves/feet/head) -> candidate display ids (shared across families).
+	private static final EnumMap<CrystalType, EnumMap<BodyPart, List<Integer>>> EXTREMITY_POOLS = new EnumMap<>(CrystalType.class);
+	// weapon kind -> grade -> candidate display ids.
+	private static final Map<WeaponKind, EnumMap<CrystalType, List<Integer>>> WEAPON_POOLS = new EnumMap<>(WeaponKind.class);
+	// grade -> candidate shield display ids (for tanks / swordsingers).
+	private static final EnumMap<CrystalType, List<Integer>> SHIELDS = new EnumMap<>(CrystalType.class);
+	private static volatile boolean _poolsBuilt = false;
 
 	// Races eligible for generated bots, weighted by repetition (humans most common, dwarves least).
 	private static final Race[] RACE_POOL =
@@ -185,7 +263,8 @@ public class FakePlayerAppearanceFactory
 	{
 		final Race race = (dominantRace != null) && (forceRace || (Rnd.get(100) < 82)) ? dominantRace : RACE_POOL[Rnd.get(RACE_POOL.length)];
 		final boolean female = (race != Race.ORC) && (race != Race.DWARF) ? Rnd.nextBoolean() : Rnd.get(100) < 30; // orcs/dwarves skew male
-		final int classId = classForRace(race)[Rnd.get(classForRace(race).length)];
+		final int level = Rnd.get(minLevel, maxLevel);
+		final int classId = pickClassId(race, level); // a class whose occupation tier fits the rolled level
 		final PlayerClass playerClass = PlayerClass.getPlayerClass(classId);
 
 		final FakePlayerAppearance look = new FakePlayerAppearance();
@@ -196,94 +275,382 @@ public class FakePlayerAppearanceFactory
 		{
 			look.setPlayerClass(playerClass);
 		}
-		look.setLevel(Rnd.get(minLevel, maxLevel));
+		look.setLevel(level);
 		look.setHairStyle(Rnd.get(0, 3));
 		look.setHairColor(Rnd.get(0, 3));
 		look.setFace(Rnd.get(0, 2));
-		equip(look, playerClass != null && playerClass.isMage());
+		equip(look, playerClass);
 		return look;
 	}
 
 	/**
-	 * Dresses a generated bot in a coherent gear set for its level tier, branched by fighter/mage.
-	 * Some slots are intentionally left empty at random so the crowd is not uniformly fully geared.
+	 * Dresses a generated bot in a coherent, complete gear set for its level, matching its class archetype (the
+	 * same class-&gt;role mapping the recruited-phantom gearing uses): an archer shows a bow + light set, a knight a
+	 * sword + shield + heavy set, a mystic a robe set + magic weapon, a fist-fighter a fist weapon, and so on.
+	 * Chest, gloves and boots are always worn and legs too (unless the chest is a one-piece full-body armor); only
+	 * the helmet varies, so the crowd shows variety without random bare torsos/legs or wrong-fit gear.
 	 * @param look the appearance to equip
-	 * @param mage {@code true} for a caster loadout (staff/wand), {@code false} for melee
+	 * @param playerClass the bot's class (drives the weapon kind + armor family); {@code null} falls back to a plain fighter
 	 */
-	private static void equip(FakePlayerAppearance look, boolean mage)
+	private static void equip(FakePlayerAppearance look, PlayerClass playerClass)
 	{
-		// The tier a bot's level would allow.
-		final int level = look.getLevel();
-		final int levelTier = level >= 40 ? 2 : level >= 20 ? 1 : 0;
+		buildPools();
 
-		// "Wealth" spreads gear grades within a same-level crowd so a cluster is not all in identical
-		// top gear: most people are poor/average and only a minority are fully kitted for their level.
+		// Archetype from the class - shared source of truth with the recruited-phantom gearing.
+		final PhantomManager.PartyRole role = (playerClass != null) ? PhantomManager.roleForClass(playerClass) : PhantomManager.PartyRole.WARRIOR;
+
+		// Grade the bot's level allows, spread by "wealth" so a same-level crowd is not all in identical top gear:
+		// most are poor (no-grade) or average (a grade under), a minority fully kitted for their level.
+		final CrystalType levelGrade = gradeForLevel(look.getLevel());
 		final int wealth = Rnd.get(100);
-		final int tier;
+		final CrystalType grade;
 		if (wealth < 40)
 		{
-			tier = 0; // poor: plain no-grade regardless of level
+			grade = CrystalType.NONE; // poor: plain no-grade
 		}
 		else if (wealth < 85)
 		{
-			tier = Math.max(0, levelTier - Rnd.get(0, 1)); // average: their tier, often a grade lower
+			grade = stepDown(levelGrade, Rnd.get(0, 1)); // average: their grade, often one lower
 		}
 		else
 		{
-			tier = levelTier; // well-off: full tier for their level
+			grade = levelGrade; // well-off: full grade for their level
 		}
 
-		// Weapon: most carry one, some go unarmed; a few show a small enchant.
+		// Armor family from the archetype: robe (MAGIC) for casters, LIGHT for archers/daggers/monks, HEAVY for
+		// tanks/warriors/singer/dancer.
+		final ArmorType family = role.armor;
+
+		// A coherent matching armor set for the family/grade (Karmian, Full Plate, ...), so the bot wears a real
+		// set instead of a random mix. Any slot the set does not define is filled from the generic pools below.
+		final FakePlayerArmorSets.Outfit outfit = FakePlayerArmorSets.random(family, grade);
+
+		// Weapon: most carry one, a few go unarmed; a minority show a small enchant. Kind matches the archetype
+		// (bow/dagger/dual/fist/1H-sword/magic); tanks and swordsingers also get a shield (the set's, if any).
 		if (Rnd.get(100) < 88)
 		{
-			final int[] weapons = mage ? (tier == 2 ? C_MAGE_WEAPONS : tier == 1 ? D_MAGE_WEAPONS : NG_MAGE_WEAPONS) : (tier == 2 ? C_FIGHTER_WEAPONS : tier == 1 ? D_FIGHTER_WEAPONS : NG_FIGHTER_WEAPONS);
-			look.setWeapon(weapons[Rnd.get(weapons.length)], 0);
-			if ((tier > 0) && (Rnd.get(100) < 12))
+			int rHand = pickWeapon(weaponKindForRole(role), grade);
+			if (rHand <= 0) // a kind/grade gap - fall back so a bot is not left barehanded
 			{
-				look.setWeaponEnchantLevel(Rnd.get(1, 4));
+				rHand = pickWeapon(role.mage ? WeaponKind.MAGIC : WeaponKind.SWORD, grade);
+			}
+			if (rHand > 0)
+			{
+				int lHand = 0;
+				if ((role == PhantomManager.PartyRole.TANK) || (role == PhantomManager.PartyRole.SINGER))
+				{
+					lHand = ((outfit != null) && (outfit.shield > 0)) ? outfit.shield : pickShield(grade);
+				}
+				look.setWeapon(rHand, lHand);
+				if ((grade != CrystalType.NONE) && (Rnd.get(100) < 12))
+				{
+					look.setWeaponEnchantLevel(Rnd.get(1, 4));
+				}
 			}
 		}
 
-		// Armor pieces for the rolled tier; chest is picked here, the rest are tier constants.
-		final int chest;
-		final int legs;
-		final int head;
-		final int gloves;
-		final int feet;
-		switch (tier)
+		// Body armor from the set (chest + legs, unless the chest is a one-piece full body armor); if there is no
+		// set for this family/grade, fall back to a family chest (+ legs) so the bot is never bare-chested.
+		int chest;
+		int legs = 0;
+		if (outfit != null)
 		{
-			case 2:
+			chest = outfit.chest;
+			legs = outfit.onepiece ? 0 : ((outfit.legs > 0) ? outfit.legs : pickArmor(family, grade, BodyPart.LEGS));
+		}
+		else
+		{
+			final int full = pickArmor(family, grade, BodyPart.FULL_ARMOR);
+			final int upper = pickArmor(family, grade, BodyPart.CHEST);
+			if ((full > 0) && ((upper <= 0) || Rnd.nextBoolean()))
 			{
-				chest = C_CHEST[Rnd.get(C_CHEST.length)];
-				legs = C_LEGS;
-				head = C_HEAD;
-				feet = C_FEET;
-				gloves = NG_GLOVES;
-				break;
+				chest = full; // one-piece body armor - no separate leg item
 			}
-			case 1:
+			else if (upper > 0)
 			{
-				chest = D_CHEST[Rnd.get(D_CHEST.length)];
-				legs = D_LEGS[Rnd.get(D_LEGS.length)];
-				head = D_HEAD;
-				feet = D_FEET;
-				gloves = NG_GLOVES;
-				break;
+				chest = upper;
+				legs = pickArmor(family, grade, BodyPart.LEGS);
 			}
-			default:
+			else
 			{
-				chest = NG_CHEST[Rnd.get(NG_CHEST.length)];
-				legs = NG_LEGS;
-				head = NG_HEAD;
-				feet = NG_FEET;
-				gloves = NG_GLOVES;
-				break;
+				chest = full;
 			}
 		}
 
-		// Completeness varies a lot: most wear a chest, fewer wear legs, helmets/gloves are uncommon
-		// (so we don't get a cluster of identical fully-armored clones).
-		look.setArmor(Rnd.get(100) < 40 ? head : 0, Rnd.get(100) < 88 ? chest : 0, Rnd.get(100) < 70 ? legs : 0, Rnd.get(100) < 38 ? gloves : 0, Rnd.get(100) < 75 ? feet : 0, 0);
+		// Gloves and boots always; helmet a bit over half the time. Prefer the set's matching piece, else a
+		// generic one from the family-agnostic extremity pool.
+		final int gloves = ((outfit != null) && (outfit.gloves > 0)) ? outfit.gloves : pickExtremity(grade, BodyPart.GLOVES);
+		final int feet = ((outfit != null) && (outfit.feet > 0)) ? outfit.feet : pickExtremity(grade, BodyPart.FEET);
+		final int head = (Rnd.get(100) < 55) ? (((outfit != null) && (outfit.head > 0)) ? outfit.head : pickExtremity(grade, BodyPart.HEAD)) : 0;
+		look.setArmor(head, chest, legs, gloves, feet, 0);
+	}
+
+	/** Highest gear grade a bot of this level would carry (aligned with Interlude expertise level gates). */
+	private static CrystalType gradeForLevel(int level)
+	{
+		if (level < 20)
+		{
+			return CrystalType.NONE;
+		}
+		if (level < 40)
+		{
+			return CrystalType.D;
+		}
+		if (level < 52)
+		{
+			return CrystalType.C;
+		}
+		if (level < 61)
+		{
+			return CrystalType.B;
+		}
+		if (level < 76)
+		{
+			return CrystalType.A;
+		}
+		return CrystalType.S;
+	}
+
+	/** {@code grade} lowered by {@code steps} tiers, clamped at NO-GRADE. */
+	private static CrystalType stepDown(CrystalType grade, int steps)
+	{
+		return CrystalType.values()[Math.max(0, grade.ordinal() - steps)];
+	}
+
+	/** A random body-armor display id for the family/slot at {@code grade}, stepping down a grade if empty; 0 if none. */
+	private static int pickArmor(ArmorType family, CrystalType grade, BodyPart slot)
+	{
+		final EnumMap<CrystalType, EnumMap<BodyPart, List<Integer>>> byGrade = ARMOR_POOLS.get(family);
+		if (byGrade == null)
+		{
+			return 0;
+		}
+		for (int ord = grade.ordinal(); ord >= 0; ord--)
+		{
+			final List<Integer> list = byGrade.get(CrystalType.values()[ord]).get(slot);
+			if ((list != null) && !list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		return 0;
+	}
+
+	/** A random gloves/boots/helmet display id at {@code grade} (family-agnostic), stepping down a grade if empty; 0 if none. */
+	private static int pickExtremity(CrystalType grade, BodyPart slot)
+	{
+		for (int ord = grade.ordinal(); ord >= 0; ord--)
+		{
+			final List<Integer> list = EXTREMITY_POOLS.get(CrystalType.values()[ord]).get(slot);
+			if ((list != null) && !list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		return 0;
+	}
+
+	/** The weapon look each archetype (role) carries. */
+	private static WeaponKind weaponKindForRole(PhantomManager.PartyRole role)
+	{
+		switch (role)
+		{
+			case NUKER:
+			case HEALER:
+			case BUFFER:
+			{
+				return WeaponKind.MAGIC;
+			}
+			case ARCHER:
+			{
+				return WeaponKind.BOW;
+			}
+			case DAGGER:
+			{
+				return WeaponKind.DAGGER;
+			}
+			case DANCER:
+			{
+				return WeaponKind.DUAL;
+			}
+			case MONK:
+			{
+				return WeaponKind.FIST;
+			}
+			case TANK:
+			case SINGER:
+			{
+				return WeaponKind.SWORD_1H; // one-handed, so a shield fits
+			}
+			default: // WARRIOR and anything else - a generic sword/blunt
+			{
+				return WeaponKind.SWORD;
+			}
+		}
+	}
+
+	/** A random weapon display id of {@code kind} at {@code grade}, stepping down a grade if that one is empty; 0 if none. */
+	private static int pickWeapon(WeaponKind kind, CrystalType grade)
+	{
+		final EnumMap<CrystalType, List<Integer>> pool = WEAPON_POOLS.get(kind);
+		if (pool == null)
+		{
+			return 0;
+		}
+		for (int ord = grade.ordinal(); ord >= 0; ord--)
+		{
+			final List<Integer> list = pool.get(CrystalType.values()[ord]);
+			if ((list != null) && !list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		return 0;
+	}
+
+	/** A random shield display id at {@code grade}, stepping down a grade if that one is empty; 0 if none. */
+	private static int pickShield(CrystalType grade)
+	{
+		for (int ord = grade.ordinal(); ord >= 0; ord--)
+		{
+			final List<Integer> list = SHIELDS.get(CrystalType.values()[ord]);
+			if ((list != null) && !list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		return 0;
+	}
+
+	/** Resolves the display-gear pools from the item table once (armor by family/grade/slot, weapons by grade). */
+	private static synchronized void buildPools()
+	{
+		if (_poolsBuilt)
+		{
+			return;
+		}
+		for (ArmorType family : new ArmorType[]
+		{
+			ArmorType.LIGHT,
+			ArmorType.HEAVY,
+			ArmorType.MAGIC
+		})
+		{
+			final EnumMap<CrystalType, EnumMap<BodyPart, List<Integer>>> byGrade = new EnumMap<>(CrystalType.class);
+			for (CrystalType g : CrystalType.values())
+			{
+				final EnumMap<BodyPart, List<Integer>> bySlot = new EnumMap<>(BodyPart.class);
+				for (BodyPart bp : BODY_SLOTS)
+				{
+					bySlot.put(bp, new ArrayList<>());
+				}
+				byGrade.put(g, bySlot);
+			}
+			ARMOR_POOLS.put(family, byGrade);
+		}
+		for (CrystalType g : CrystalType.values())
+		{
+			final EnumMap<BodyPart, List<Integer>> bySlot = new EnumMap<>(BodyPart.class);
+			for (BodyPart bp : EXTREMITY_SLOTS)
+			{
+				bySlot.put(bp, new ArrayList<>());
+			}
+			EXTREMITY_POOLS.put(g, bySlot);
+		}
+		for (WeaponKind kind : WeaponKind.values())
+		{
+			final EnumMap<CrystalType, List<Integer>> byGrade = new EnumMap<>(CrystalType.class);
+			for (CrystalType g : CrystalType.values())
+			{
+				byGrade.put(g, new ArrayList<>());
+			}
+			WEAPON_POOLS.put(kind, byGrade);
+		}
+		for (CrystalType g : CrystalType.values())
+		{
+			SHIELDS.put(g, new ArrayList<>());
+		}
+		for (ItemTemplate item : ItemData.getInstance().getAllItems())
+		{
+			if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || !FakePlayerGearFilter.isPlayerGear(item))
+			{
+				continue; // skip pet/summon/monster gear that renders as a sack / invisible slot
+			}
+			final CrystalType grade = item.getCrystalType();
+			final int id = item.getId();
+			if (item instanceof Armor)
+			{
+				final ArmorType at = ((Armor) item).getItemType();
+				if (at == ArmorType.SHIELD)
+				{
+					SHIELDS.get(grade).add(id);
+					continue;
+				}
+				final BodyPart bp = item.getBodyPart();
+				if ((bp == BodyPart.GLOVES) || (bp == BodyPart.FEET) || (bp == BodyPart.HEAD)) // family-agnostic (ArmorType.NONE)
+				{
+					EXTREMITY_POOLS.get(grade).get(bp).add(id);
+					continue;
+				}
+				final EnumMap<CrystalType, EnumMap<BodyPart, List<Integer>>> byGrade = ARMOR_POOLS.get(at);
+				if (byGrade == null) // SIGIL / NONE without a body slot we dress
+				{
+					continue;
+				}
+				final List<Integer> list = byGrade.get(grade).get(bp); // CHEST / LEGS / FULL_ARMOR
+				if (list != null)
+				{
+					list.add(id);
+				}
+			}
+			else if (item instanceof Weapon)
+			{
+				if (item.isMagicWeapon())
+				{
+					WEAPON_POOLS.get(WeaponKind.MAGIC).get(grade).add(id);
+					continue;
+				}
+				switch (((Weapon) item).getItemType())
+				{
+					case SWORD:
+					case BLUNT:
+					{
+						WEAPON_POOLS.get(WeaponKind.SWORD).get(grade).add(id);
+						if (item.getBodyPart() == BodyPart.R_HAND) // one-handed - usable with a shield
+						{
+							WEAPON_POOLS.get(WeaponKind.SWORD_1H).get(grade).add(id);
+						}
+						break;
+					}
+					case DAGGER:
+					{
+						WEAPON_POOLS.get(WeaponKind.DAGGER).get(grade).add(id);
+						break;
+					}
+					case BOW:
+					{
+						WEAPON_POOLS.get(WeaponKind.BOW).get(grade).add(id);
+						break;
+					}
+					case DUAL:
+					{
+						WEAPON_POOLS.get(WeaponKind.DUAL).get(grade).add(id);
+						break;
+					}
+					case FIST:
+					case DUALFIST:
+					{
+						WEAPON_POOLS.get(WeaponKind.FIST).get(grade).add(id);
+						break;
+					}
+					default:
+					{
+						break;
+					}
+				}
+			}
+		}
+		_poolsBuilt = true;
 	}
 
 	/**
@@ -303,29 +670,38 @@ public class FakePlayerAppearanceFactory
 		return SELL_TITLES[Rnd.get(SELL_TITLES.length)];
 	}
 
-	private static int[] classForRace(Race race)
+	/** A class id for the race whose occupation tier fits {@code level} (base &lt;20, first 20-39, second 40+). */
+	private static int pickClassId(Race race, int level)
+	{
+		final int[][] tiers = tiersForRace(race);
+		final int tier = (level < 20) ? 0 : (level < 40) ? 1 : 2;
+		final int[] pool = tiers[Math.min(tier, tiers.length - 1)];
+		return pool[Rnd.get(pool.length)];
+	}
+
+	private static int[][] tiersForRace(Race race)
 	{
 		switch (race)
 		{
 			case ELF:
 			{
-				return ELF_CLASSES;
+				return ELF_TIERS;
 			}
 			case DARK_ELF:
 			{
-				return DARK_ELF_CLASSES;
+				return DARK_ELF_TIERS;
 			}
 			case ORC:
 			{
-				return ORC_CLASSES;
+				return ORC_TIERS;
 			}
 			case DWARF:
 			{
-				return DWARF_CLASSES;
+				return DWARF_TIERS;
 			}
 			default:
 			{
-				return HUMAN_CLASSES;
+				return HUMAN_TIERS;
 			}
 		}
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerArmorSets.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerArmorSets.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2013 L2jMobius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.l2jmobius.gameserver.managers;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+
+import org.l2jmobius.commons.util.Rnd;
+import org.l2jmobius.gameserver.data.holders.ArmorSet;
+import org.l2jmobius.gameserver.data.xml.ArmorSetData;
+import org.l2jmobius.gameserver.data.xml.ItemData;
+import org.l2jmobius.gameserver.model.item.Armor;
+import org.l2jmobius.gameserver.model.item.ItemTemplate;
+import org.l2jmobius.gameserver.model.item.enums.BodyPart;
+import org.l2jmobius.gameserver.model.item.type.ArmorType;
+import org.l2jmobius.gameserver.model.item.type.CrystalType;
+
+/**
+ * Turns the game's own armor-set definitions ({@code data/stats/armorsets/**}, loaded by {@link ArmorSetData})
+ * into ready-to-wear matching outfits for fake players and phantoms, so a bot wears a coherent set (Karmian,
+ * Full Plate, Mithril, ...) instead of a random mix of unrelated pieces. Only sets whose chest is player gear
+ * (see {@link FakePlayerGearFilter}) are used, and each piece is likewise kept only if it is player gear, so the
+ * outfits stay render-safe on every race. Family (light/heavy/robe) and grade come from the chest item.
+ */
+public class FakePlayerArmorSets
+{
+	/** A matching armor outfit. Any slot may be 0 (the set does not define it / it is not player gear); when the
+	 * chest is a one-piece full body armor, {@code legs} is 0 by design. */
+	public static class Outfit
+	{
+		public final int chest;
+		public final boolean onepiece;
+		public final int legs;
+		public final int gloves;
+		public final int feet;
+		public final int head;
+		public final int shield;
+
+		Outfit(int chest, boolean onepiece, int legs, int gloves, int feet, int head, int shield)
+		{
+			this.chest = chest;
+			this.onepiece = onepiece;
+			this.legs = legs;
+			this.gloves = gloves;
+			this.feet = feet;
+			this.head = head;
+			this.shield = shield;
+		}
+	}
+
+	// family (LIGHT/HEAVY/MAGIC) -> grade -> matching outfits.
+	private static final EnumMap<ArmorType, EnumMap<CrystalType, List<Outfit>>> SETS = new EnumMap<>(ArmorType.class);
+	private static volatile boolean _built = false;
+
+	private FakePlayerArmorSets()
+	{
+	}
+
+	/** First player-gear id in {@code ids}, or 0 if none (drops set pieces that are not render-safe player gear). */
+	private static int firstAllowed(List<Integer> ids)
+	{
+		if (ids != null)
+		{
+			for (int id : ids)
+			{
+				if (FakePlayerGearFilter.isPlayerGear(id))
+				{
+					return id;
+				}
+			}
+		}
+		return 0;
+	}
+
+	private static synchronized void build()
+	{
+		if (_built)
+		{
+			return;
+		}
+		for (ArmorType family : new ArmorType[]
+		{
+			ArmorType.LIGHT,
+			ArmorType.HEAVY,
+			ArmorType.MAGIC
+		})
+		{
+			final EnumMap<CrystalType, List<Outfit>> byGrade = new EnumMap<>(CrystalType.class);
+			for (CrystalType g : CrystalType.values())
+			{
+				byGrade.put(g, new ArrayList<>());
+			}
+			SETS.put(family, byGrade);
+		}
+		int built = 0;
+		for (ItemTemplate item : ItemData.getInstance().getAllItems())
+		{
+			if (!(item instanceof Armor))
+			{
+				continue;
+			}
+			final int chestId = item.getId();
+			if (!FakePlayerGearFilter.isPlayerGear(chestId) || !ArmorSetData.getInstance().isArmorSet(chestId))
+			{
+				continue;
+			}
+			final ArmorType family = ((Armor) item).getItemType();
+			if ((family != ArmorType.LIGHT) && (family != ArmorType.HEAVY) && (family != ArmorType.MAGIC))
+			{
+				continue; // the set chest must be a light/heavy/robe body piece
+			}
+			final ArmorSet set = ArmorSetData.getInstance().getSet(chestId);
+			if (set == null)
+			{
+				continue;
+			}
+			final boolean onepiece = item.getBodyPart() == BodyPart.FULL_ARMOR;
+			final Outfit outfit = new Outfit(chestId, onepiece, firstAllowed(set.getLegs()), firstAllowed(set.getGloves()), firstAllowed(set.getFeet()), firstAllowed(set.getHead()), firstAllowed(set.getShieldIds()));
+			SETS.get(family).get(item.getCrystalType()).add(outfit);
+			built++;
+		}
+		if (built > 0) // only cache once real data is present (guards against a call before ArmorSetData/BuyListData load)
+		{
+			_built = true;
+		}
+	}
+
+	/**
+	 * A random matching outfit for the armor {@code family} at {@code grade}: prefers the requested grade, then
+	 * steps down, then up, so a family with no set at the exact grade (e.g. no No-Grade heavy set) still yields a
+	 * complete outfit rather than a bare bot.
+	 * @return an {@link Outfit}, or {@code null} if the family has no usable set at all
+	 */
+	public static Outfit random(ArmorType family, CrystalType grade)
+	{
+		build();
+		final EnumMap<CrystalType, List<Outfit>> byGrade = SETS.get(family);
+		if (byGrade == null)
+		{
+			return null;
+		}
+		final CrystalType[] grades = CrystalType.values();
+		for (int ord = grade.ordinal(); ord >= 0; ord--)
+		{
+			final List<Outfit> list = byGrade.get(grades[ord]);
+			if (!list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		for (int ord = grade.ordinal() + 1; ord < grades.length; ord++)
+		{
+			final List<Outfit> list = byGrade.get(grades[ord]);
+			if (!list.isEmpty())
+			{
+				return list.get(Rnd.get(list.size()));
+			}
+		}
+		return null;
+	}
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerGearFilter.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerGearFilter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2013 L2jMobius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.l2jmobius.gameserver.managers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.l2jmobius.gameserver.data.xml.BuyListData;
+import org.l2jmobius.gameserver.model.buylist.BuyListHolder;
+import org.l2jmobius.gameserver.model.buylist.Product;
+import org.l2jmobius.gameserver.model.item.ItemTemplate;
+
+/**
+ * Allow-list of item ids that fake players and phantoms may wear, sourced from the <b>GM shop's gear buy-lists</b>
+ * (the ones the {@code data/html/admin/gmstore/gear/**} panels open via {@code admin_buy}). That union is a
+ * hand-curated, render-safe set of player equipment:
+ * <ul>
+ * <li>pet/summon gear lives in the GM shop's separate Pet Section, so it is <b>not</b> in these lists - no
+ * pet/monster deny-list needed;</li>
+ * <li>armor pieces with no model for some race (e.g. "Tunic of Mana", which is invisible on an Orc mystic) were
+ * deliberately left out of the GM gear lists, so drawing only from here <b>needs no race-specific skip</b>.</li>
+ * </ul>
+ * The only residue is a handful of NPC weapons named "Monster Only(...)" that sit in the weapon lists; those are
+ * dropped by name when the allow-list is built.
+ * <p>
+ * The allow-list is resolved lazily from {@link BuyListData} (already loaded at start-up) the first time gear is
+ * built, so it stays in sync automatically if a buy-list is edited. If a listed buy-list id is missing it is
+ * skipped. The set is only cached once it is non-empty, so a premature call (before BuyListData finished loading)
+ * fails soft and rebuilds on the next call rather than caching an empty allow-list.
+ */
+public class FakePlayerGearFilter
+{
+	// GM shop weapon/armor/jewel buy-list ids, from data/html/admin/gmstore/gear/** (admin_buy <id>).
+	private static final int[] GEAR_BUYLISTS =
+	{
+		9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, //
+		9011, 9012, 9013, 9014, 9015, 9016, 9017, 9018, 9019, 9020, //
+		9021, 9022, 9023, 9024, 9025, 9026, 9027, 9028, 9029, 9030, //
+		9031, 9032, 9033, 9034, 9035, 9036, 9037, 9038, 9039, 9040, //
+		9041, 9042, 9043, 9044, 9045, 9046, 9047, 9048, 9049, 9050, //
+		9051, 9052, 9053, 9917, 9925, 9951, 9952, 9953, 9954, 9955, //
+		9956, 9959, 9960, 9961, 9962, 9963, 9964, 9965, 9980, 9997, 9998
+	};
+
+	private static volatile Set<Integer> _allowed = null;
+
+	private FakePlayerGearFilter()
+	{
+	}
+
+	private static Set<Integer> allowed()
+	{
+		Set<Integer> set = _allowed;
+		if (set != null)
+		{
+			return set;
+		}
+		synchronized (FakePlayerGearFilter.class)
+		{
+			set = _allowed;
+			if (set != null)
+			{
+				return set;
+			}
+			final Set<Integer> built = new HashSet<>(2048);
+			for (int listId : GEAR_BUYLISTS)
+			{
+				final BuyListHolder buyList = BuyListData.getInstance().getBuyList(listId);
+				if (buyList == null)
+				{
+					continue;
+				}
+				for (Product product : buyList.getProducts())
+				{
+					final ItemTemplate item = product.getItem();
+					if ((item != null) && !item.getName().contains("Monster Only")) // drop NPC weapons that leaked into the gear lists
+					{
+						built.add(item.getId());
+					}
+				}
+			}
+			if (built.isEmpty()) // BuyListData not ready yet - don't cache an empty allow-list, retry next call
+			{
+				return built;
+			}
+			_allowed = built;
+			return built;
+		}
+	}
+
+	/** @return {@code true} if {@code itemId} is player gear the GM shop sells (safe to render on any race/class). */
+	public static boolean isPlayerGear(int itemId)
+	{
+		return allowed().contains(itemId);
+	}
+
+	/** @return {@code true} if {@code item} is player gear the GM shop sells (safe to render on any race/class). */
+	public static boolean isPlayerGear(ItemTemplate item)
+	{
+		return (item != null) && allowed().contains(item.getId());
+	}
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomManager.java
@@ -61,7 +61,6 @@ import org.l2jmobius.gameserver.model.WorldObject;
 import org.l2jmobius.gameserver.model.actor.Creature;
 import org.l2jmobius.gameserver.model.actor.Player;
 import org.l2jmobius.gameserver.model.actor.appearance.PlayerAppearance;
-import org.l2jmobius.gameserver.model.actor.enums.creature.Race;
 import org.l2jmobius.gameserver.model.actor.enums.player.PlayerClass;
 import org.l2jmobius.gameserver.model.actor.holders.player.AutoPlaySettingsHolder;
 import org.l2jmobius.gameserver.model.actor.holders.player.AutoUseSettingsHolder;
@@ -257,12 +256,13 @@ public class PhantomManager implements IXmlReader
 	// loadouts: fighters (sword + light/heavy armor) and mages (magic weapon + robe).
 	private static final Map<BodyPart, EnumMap<CrystalType, List<ItemTemplate>>> FIGHTER_GEAR = new EnumMap<>(BodyPart.class);
 	private static final Map<BodyPart, EnumMap<CrystalType, List<ItemTemplate>>> MAGE_GEAR = new EnumMap<>(BodyPart.class);
-	// Caster armor item ids that have NO Orc-Mystic model in the client and so render invisibly on an Orc
-	// (Warcryer) - chest/legs vanish. There is no server-side attribute to detect this (identical items render
-	// differently), so it is a tested deny-list: an Orc caster is geared from everything EXCEPT these. Add ids
-	// here as the debug gear log turns up more offenders. Confirmed so far: 445 Paradia Tunic (chest),
-	// 474 Stockings of Mana (legs).
-	private static final Set<Integer> ORC_CASTER_ARMOR_SKIP = Set.of(445, 474);
+	// DISABLED (kept for reference). Caster armor item ids that have NO Orc-Mystic model in the client and so
+	// render invisibly on an Orc (Warcryer) - chest/legs vanish. There is no server-side attribute to detect this
+	// (identical items render differently), so it was a tested deny-list: an Orc caster was geared from everything
+	// EXCEPT these (445 Paradia Tunic chest, 474 Stockings of Mana legs). Turned OFF for now so orc casters draw
+	// ordinary robe and we can re-check whether the invisible-torso bug still reproduces on the live client. If it
+	// does, re-enable this and pass it as the `skip` set in gear()/gearParty() again.
+	// private static final Set<Integer> ORC_CASTER_ARMOR_SKIP = Set.of(445, 474);
 	private static volatile boolean _gearBuilt = false;
 
 	/**
@@ -335,23 +335,29 @@ public class PhantomManager implements IXmlReader
 	 */
 	public enum PartyRole
 	{
-		TANK(false, BuddyRole.NONE),
-		WARRIOR(false, BuddyRole.NONE),
-		ARCHER(false, BuddyRole.NONE),
-		DAGGER(false, BuddyRole.NONE),
-		SINGER(false, BuddyRole.NONE), // Swordsinger: melee that keeps the party's songs running (2-min recast loop)
-		DANCER(false, BuddyRole.NONE), // Bladedancer: dual-wield melee that keeps the dances running
-		NUKER(true, BuddyRole.NONE),
-		HEALER(true, BuddyRole.ELDER), // Elven Elder kit (heals + recharge); granted Resurrection on spawn
-		BUFFER(true, BuddyRole.PROPHET); // Prophet fighter-buff kit
+		// The armor field is the class's practical armor family (from its datapack armor-mastery skill, cross-checked
+		// against community Interlude builds): Heavy for tanks/warriors/singer/dancer, Light for archers/daggers,
+		// MAGIC (=robe) for casters. It drives gearParty's armor pick so an archer no longer rolls heavy plate, etc.
+		TANK(false, BuddyRole.NONE, ArmorType.HEAVY),
+		WARRIOR(false, BuddyRole.NONE, ArmorType.HEAVY),
+		ARCHER(false, BuddyRole.NONE, ArmorType.LIGHT),
+		DAGGER(false, BuddyRole.NONE, ArmorType.LIGHT),
+		MONK(false, BuddyRole.NONE, ArmorType.LIGHT), // Orc Monk / Tyrant / Grand Khavatari: unarmed (fist) light-armor melee bruiser
+		SINGER(false, BuddyRole.NONE, ArmorType.HEAVY), // Swordsinger: melee that keeps the party's songs running (2-min recast loop)
+		DANCER(false, BuddyRole.NONE, ArmorType.HEAVY), // Bladedancer: dual-wield melee that keeps the dances running (Heavy + dual swords is the retail standard)
+		NUKER(true, BuddyRole.NONE, ArmorType.MAGIC),
+		HEALER(true, BuddyRole.ELDER, ArmorType.MAGIC), // Elven Elder kit (heals + recharge); granted Resurrection on spawn
+		BUFFER(true, BuddyRole.PROPHET, ArmorType.MAGIC); // Prophet fighter-buff kit
 
 		final boolean mage;
 		final BuddyRole supportAs;
+		final ArmorType armor;
 
-		PartyRole(boolean mage, BuddyRole supportAs)
+		PartyRole(boolean mage, BuddyRole supportAs, ArmorType armor)
 		{
 			this.mage = mage;
 			this.supportAs = supportAs;
+			this.armor = armor;
 		}
 
 		/** @return {@code true} for HEALER/BUFFER: outfit via the support path, behaviour driven by hand. */
@@ -450,6 +456,14 @@ public class PhantomManager implements IXmlReader
 				{
 					return DANCER;
 				}
+				case "monk":
+				case "tyrant":
+				case "fist":
+				case "gk":
+				case "khavatari":
+				{
+					return MONK;
+				}
 				default:
 				{
 					return null;
@@ -465,7 +479,8 @@ public class PhantomManager implements IXmlReader
 				WARRIOR,
 				ARCHER,
 				DAGGER,
-				NUKER
+				NUKER,
+				MONK
 			};
 			return dps[Rnd.get(dps.length)];
 		}
@@ -528,6 +543,14 @@ public class PhantomManager implements IXmlReader
 		if (playerClass.isMage())
 		{
 			return PartyRole.NUKER;
+		}
+		if (nameHas(name, "monk", "tyrant", "khavatari")) // Orc fist-fighters: light armor + fist weapon
+		{
+			return PartyRole.MONK;
+		}
+		if (nameHas(name, "scavenger", "bounty", "artisan", "warsmith", "seeker", "maestro")) // Dwarves: blunt/heavy melee, not daggers (despite "hunter"/"seeker" in the names)
+		{
+			return PartyRole.WARRIOR;
 		}
 		if (nameHas(name, "ranger", "hawkeye", "sentinel", "sagittarius", "scout", "archer"))
 		{
@@ -2023,40 +2046,87 @@ public class PhantomManager implements IXmlReader
 		phantom.getAutoUseSettings().setAutoPotionItem(HP_POTION_ID);
 		phantom.getAutoPlaySettings().setAutoPotionPercent(HP_POTION_PERCENT);
 
-		// Armor pieces: a varied at-or-below-grade piece per slot. Completeness varies (chest almost
-		// always, helmet/gloves often skipped) so a group is not a row of identical fully-armored clones.
-		// Orc casters (Warcryer) skip the armor ids that have no orc model and would render invisibly.
-		final Set<Integer> skip = (mage && (phantom.getRace() == Race.ORC)) ? ORC_CASTER_ARMOR_SKIP : null;
-		for (BodyPart slot : GEAR_SLOTS)
-		{
-			if (slot == BodyPart.R_HAND)
-			{
-				continue;
-			}
-			if ((slot == BodyPart.HEAD) && (Rnd.get(100) >= 55))
-			{
-				continue;
-			}
-			if ((slot == BodyPart.GLOVES) && (Rnd.get(100) >= 60))
-			{
-				continue;
-			}
-			if ((slot == BodyPart.FEET) && (Rnd.get(100) >= 85))
-			{
-				continue;
-			}
-			if ((slot == BodyPart.LEGS) && (Rnd.get(100) >= 92))
-			{
-				continue;
-			}
-			final ItemTemplate piece = pickForSlot(set, slot, desired, skip);
-			if (piece != null)
-			{
-				equip(phantom, piece);
-			}
-		}
+		// Armor: a full matching set (Karmian / Mithril / Full Plate, ...) for the loadout's family, so a field
+		// hunter wears a coherent outfit instead of a random per-slot mix. Fighters roll light or heavy for variety.
+		final ArmorType family = mage ? ArmorType.MAGIC : (Rnd.get(100) < 55 ? ArmorType.LIGHT : ArmorType.HEAVY);
+		equipArmorSet(phantom, family, desired, 0, false);
+
+		// Jewelry: necklace + two earrings + two rings, for the extra P./M.Def that keeps a field hunter alive.
+		equipJewelry(phantom, BodyPart.NECK, desired, 1);
+		equipJewelry(phantom, BodyPart.LR_EAR, desired, 2);
+		equipJewelry(phantom, BodyPart.LR_FINGER, desired, 2);
+
 		// No broadcast here: gear() runs before the phantom enters the world, so the whole set is in place
 		// for the spawn CharInfo (enterWorld broadcasts afterwards).
+	}
+
+	/**
+	 * Equips a coherent matching armor set (from {@link FakePlayerArmorSets}) for {@code family}/{@code grade},
+	 * filling any slot the set does not define from the best in-family (body) or generic (extremity) piece, so no
+	 * slot is left bare. A one-piece full-body chest correctly leaves the legs slot empty. With {@code wantShield}
+	 * the set's shield (or the best shield in grade) is added.
+	 */
+	private void equipArmorSet(Player phantom, ArmorType family, CrystalType grade, int enchant, boolean wantShield)
+	{
+		final FakePlayerArmorSets.Outfit outfit = FakePlayerArmorSets.random(family, grade);
+		if (outfit == null)
+		{
+			// No set for this family/grade - fall back to best per-slot (body family-correct, extremities agnostic).
+			for (BodyPart slot : GEAR_SLOTS)
+			{
+				if (slot == BodyPart.R_HAND)
+				{
+					continue;
+				}
+				final ItemTemplate piece = bestArmor(slot, grade, family, null);
+				if (piece != null)
+				{
+					equip(phantom, piece, enchant);
+				}
+			}
+			if (wantShield)
+			{
+				equipPiece(phantom, bestEquip(grade, item -> (item instanceof Armor) && (((Armor) item).getItemType() == ArmorType.SHIELD)), enchant);
+			}
+			return;
+		}
+		equipById(phantom, outfit.chest, enchant);
+		if (!outfit.onepiece)
+		{
+			equipPiece(phantom, (outfit.legs > 0) ? ItemData.getInstance().getTemplate(outfit.legs) : bestArmor(BodyPart.LEGS, grade, family, null), enchant);
+		}
+		equipPiece(phantom, (outfit.gloves > 0) ? ItemData.getInstance().getTemplate(outfit.gloves) : bestArmor(BodyPart.GLOVES, grade, family, null), enchant);
+		equipPiece(phantom, (outfit.feet > 0) ? ItemData.getInstance().getTemplate(outfit.feet) : bestArmor(BodyPart.FEET, grade, family, null), enchant);
+		equipPiece(phantom, (outfit.head > 0) ? ItemData.getInstance().getTemplate(outfit.head) : bestArmor(BodyPart.HEAD, grade, family, null), enchant);
+		if (wantShield)
+		{
+			if (outfit.shield > 0)
+			{
+				equipById(phantom, outfit.shield, enchant);
+			}
+			else
+			{
+				equipPiece(phantom, bestEquip(grade, item -> (item instanceof Armor) && (((Armor) item).getItemType() == ArmorType.SHIELD)), enchant);
+			}
+		}
+	}
+
+	/** Resolves an item id to its template and equips it (with enchant); no-op if the id is 0 / unknown. */
+	private void equipById(Player phantom, int itemId, int enchant)
+	{
+		if (itemId > 0)
+		{
+			equipPiece(phantom, ItemData.getInstance().getTemplate(itemId), enchant);
+		}
+	}
+
+	/** Equips a resolved template (with enchant); no-op if {@code template} is {@code null}. */
+	private void equipPiece(Player phantom, ItemTemplate template, int enchant)
+	{
+		if (template != null)
+		{
+			equip(phantom, template, enchant);
+		}
 	}
 
 	/**
@@ -2104,33 +2174,11 @@ public class PhantomManager implements IXmlReader
 		phantom.getAutoUseSettings().setAutoPotionItem(HP_POTION_ID);
 		phantom.getAutoPlaySettings().setAutoPotionPercent(HP_POTION_PERCENT);
 
-		// Full armor set: every slot, best in grade, no random gaps. Orc casters still skip the ids that have no
-		// orc model and would render invisibly.
-		final Set<Integer> skip = (mage && (phantom.getRace() == Race.ORC)) ? ORC_CASTER_ARMOR_SKIP : null;
-		final boolean preferHeavy = (role == PartyRole.TANK); // a tank wants the highest mitigation it can wear
-		for (BodyPart slot : GEAR_SLOTS)
-		{
-			if (slot == BodyPart.R_HAND)
-			{
-				continue;
-			}
-			final ItemTemplate piece = bestArmor(slot, grade, mage, skip, preferHeavy);
-			if (piece != null)
-			{
-				equip(phantom, piece, enchant);
-			}
-		}
-
-		// Shield for the tank (a big chunk of a knight's mitigation + block) - and the singer, a knight-line class
-		// that fights sword-and-board while it keeps the songs running.
-		if ((role == PartyRole.TANK) || (role == PartyRole.SINGER))
-		{
-			final ItemTemplate shield = bestEquip(grade, item -> (item instanceof Armor) && (((Armor) item).getItemType() == ArmorType.SHIELD));
-			if (shield != null)
-			{
-				equip(phantom, shield, enchant);
-			}
-		}
+		// Full matching armor set in the class's practical armor family (Heavy for tanks/warriors/singer/dancer,
+		// Light for archer/dagger/monk, robe for casters) - a coherent set (Karmian / Full Plate, ...) rather than a
+		// random per-slot mix, with the tank/singer also getting the set's shield. Any slot the set omits is filled
+		// with the best in-family/generic piece.
+		equipArmorSet(phantom, role.armor, grade, enchant, (role == PartyRole.TANK) || (role == PartyRole.SINGER));
 
 		// Jewelry: necklace + two earrings + two rings (matched by body part; the engine fills both ears/fingers).
 		equipJewelry(phantom, BodyPart.NECK, grade, 1);
@@ -2198,24 +2246,40 @@ public class PhantomManager implements IXmlReader
 				return dual;
 			}
 		}
+		else if (role == PartyRole.MONK)
+		{
+			// Fist fighters (Tyrant / Grand Khavatari) wield fist weapons - the DUALFIST/FIST types.
+			final ItemTemplate fist = bestEquip(grade, item -> (item instanceof Weapon) && ((((Weapon) item).getItemType() == WeaponType.DUALFIST) || (((Weapon) item).getItemType() == WeaponType.FIST)));
+			if (fist != null)
+			{
+				return fist;
+			}
+		}
 		// Sword fallback (and the default melee weapon). A TANK or SINGER needs a ONE-handed sword so its shield fits
 		// the left hand; a two-handed sword would otherwise be unequipped when the shield goes on.
 		final boolean oneHandOnly = (role == PartyRole.TANK) || (role == PartyRole.SINGER);
 		return bestEquip(grade, item -> (item instanceof Weapon) && (((Weapon) item).getItemType() == WeaponType.SWORD) && (!oneHandOnly || (item.getBodyPart() == BodyPart.R_HAND)));
 	}
 
-	/** Best-in-grade armor piece for a slot: a tank prefers HEAVY (falls back to any), casters take MAGIC, others LIGHT/HEAVY. */
-	private static ItemTemplate bestArmor(BodyPart slot, CrystalType grade, boolean mage, Set<Integer> skip, boolean preferHeavy)
+	/**
+	 * Best-in-grade armor piece for a slot in the class's practical armor {@code family} (MAGIC=robe / LIGHT / HEAVY).
+	 * Falls back to any armor family if the desired one has no piece in that slot/grade, so a slot is never left bare
+	 * (e.g. a family that lacks a helmet at some grade still gets one rather than a hole in the set).
+	 */
+	private static ItemTemplate bestArmor(BodyPart slot, CrystalType grade, ArmorType family, Set<Integer> skip)
 	{
-		if (preferHeavy)
+		// Gloves / boots / helmet are family-agnostic (ArmorType.NONE) - any class wears any of them, so pick the
+		// best regardless of family (a family filter would match nothing and leave the slot bare).
+		if ((slot == BodyPart.GLOVES) || (slot == BodyPart.FEET) || (slot == BodyPart.HEAD))
 		{
-			final ItemTemplate heavy = bestArmorOfTypes(slot, grade, skip, EnumSet.of(ArmorType.HEAVY));
-			if (heavy != null)
-			{
-				return heavy;
-			}
+			return bestArmorOfTypes(slot, grade, skip, EnumSet.of(ArmorType.NONE, ArmorType.LIGHT, ArmorType.HEAVY, ArmorType.MAGIC));
 		}
-		return bestArmorOfTypes(slot, grade, skip, mage ? EnumSet.of(ArmorType.MAGIC) : EnumSet.of(ArmorType.LIGHT, ArmorType.HEAVY));
+		final ItemTemplate exact = bestArmorOfTypes(slot, grade, skip, EnumSet.of(family));
+		if (exact != null)
+		{
+			return exact;
+		}
+		return bestArmorOfTypes(slot, grade, skip, EnumSet.of(ArmorType.LIGHT, ArmorType.HEAVY, ArmorType.MAGIC));
 	}
 
 	private static ItemTemplate bestArmorOfTypes(BodyPart slot, CrystalType grade, Set<Integer> skip, Set<ArmorType> allowed)
@@ -2261,9 +2325,9 @@ public class PhantomManager implements IXmlReader
 			ItemTemplate best = null;
 			for (ItemTemplate item : ItemData.getInstance().getAllItems())
 			{
-				if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || (item.getCrystalType() != grade))
+				if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || (item.getCrystalType() != grade) || !FakePlayerGearFilter.isPlayerGear(item))
 				{
-					continue;
+					continue; // skip pet/summon/monster gear that renders as a sack / invisible slot
 				}
 				if (filter.test(item) && ((best == null) || (item.getReferencePrice() > best.getReferencePrice())))
 				{
@@ -2456,9 +2520,9 @@ public class PhantomManager implements IXmlReader
 			initGearMap(MAGE_GEAR);
 			for (ItemTemplate item : ItemData.getInstance().getAllItems())
 			{
-				if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0))
+				if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || !FakePlayerGearFilter.isPlayerGear(item))
 				{
-					continue;
+					continue; // skip pet/summon/monster gear that renders as a sack / invisible slot
 				}
 
 				if (item instanceof Weapon)
@@ -2479,19 +2543,27 @@ public class PhantomManager implements IXmlReader
 				else if (item instanceof Armor)
 				{
 					final BodyPart part = item.getBodyPart();
-					if ((part != BodyPart.CHEST) && (part != BodyPart.LEGS) && (part != BodyPart.GLOVES) && (part != BodyPart.FEET) && (part != BodyPart.HEAD))
+					if ((part == BodyPart.GLOVES) || (part == BodyPart.FEET) || (part == BodyPart.HEAD))
 					{
-						continue; // skip FULL_ARMOR (conflicts with separate legs) and non-armor slots
-					}
-					final ArmorType type = ((Armor) item).getItemType();
-					if ((type == ArmorType.LIGHT) || (type == ArmorType.HEAVY))
-					{
+						// Gloves / boots / helmet are family-agnostic (ArmorType.NONE) - any class wears them, so
+						// they go into both the fighter and the mage loadout. (Without this they'd be dropped by
+						// the family check below and phantoms would show bare hands/feet/head.)
 						FIGHTER_GEAR.get(part).get(item.getCrystalType()).add(item);
-					}
-					else if (type == ArmorType.MAGIC)
-					{
 						MAGE_GEAR.get(part).get(item.getCrystalType()).add(item);
 					}
+					else if ((part == BodyPart.CHEST) || (part == BodyPart.LEGS))
+					{
+						final ArmorType type = ((Armor) item).getItemType();
+						if ((type == ArmorType.LIGHT) || (type == ArmorType.HEAVY))
+						{
+							FIGHTER_GEAR.get(part).get(item.getCrystalType()).add(item);
+						}
+						else if (type == ArmorType.MAGIC)
+						{
+							MAGE_GEAR.get(part).get(item.getCrystalType()).add(item);
+						}
+					}
+					// else FULL_ARMOR (conflicts with separate legs), shields and jewelry - not used by the ambient loadout
 				}
 			}
 			trimGear(FIGHTER_GEAR);
@@ -3114,6 +3186,15 @@ public class PhantomManager implements IXmlReader
 					11,
 					12
 				}[tier]; // Human Mage / Wizard / Sorcerer
+			}
+			case MONK:
+			{
+				return new int[]
+				{
+					44,
+					47,
+					48
+				}[tier]; // Orc Fighter / Orc Monk / Tyrant
 			}
 			default:
 			{

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -3151,7 +3151,7 @@ public class PhantomPartyManager
 		{
 			return true; // the real human leader - always protect the player
 		}
-		return (m.role != PartyRole.WARRIOR) && (m.role != PartyRole.DAGGER) && (m.role != PartyRole.TANK);
+		return (m.role != PartyRole.WARRIOR) && (m.role != PartyRole.DAGGER) && (m.role != PartyRole.MONK) && (m.role != PartyRole.TANK);
 	}
 
 	/** {@code true} if {@code who} is a member of this tank's party (so a mob on it is a threat to protect against). */

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/network/serverpackets/FakePlayerInfo.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/network/serverpackets/FakePlayerInfo.java
@@ -22,10 +22,12 @@ package org.l2jmobius.gameserver.network.serverpackets;
 
 import org.l2jmobius.commons.network.WritableBuffer;
 import org.l2jmobius.gameserver.data.sql.ClanTable;
+import org.l2jmobius.gameserver.data.xml.PlayerTemplateData;
 import org.l2jmobius.gameserver.model.actor.Npc;
 import org.l2jmobius.gameserver.model.actor.enums.player.Sex;
 import org.l2jmobius.gameserver.model.actor.holders.npc.FakePlayerAppearance;
 import org.l2jmobius.gameserver.model.actor.holders.npc.FakePlayerHolder;
+import org.l2jmobius.gameserver.model.actor.templates.PlayerTemplate;
 import org.l2jmobius.gameserver.model.clan.Clan;
 import org.l2jmobius.gameserver.network.GameClient;
 import org.l2jmobius.gameserver.network.ServerPackets;
@@ -51,6 +53,8 @@ public class FakePlayerInfo extends ServerPacket
 	private final int _flyWalkSpd;
 	private final double _moveMultiplier;
 	private final float _attackSpeedMultiplier;
+	private final double _collisionRadius;
+	private final double _collisionHeight;
 	private final FakePlayerHolder _fpcHolder;
 	private final FakePlayerAppearance _look; // per-instance override; null = use template
 	private final Clan _clan;
@@ -74,6 +78,23 @@ public class FakePlayerInfo extends ServerPacket
 		_swimWalkSpd = (int) Math.round(npc.getSwimWalkSpeed() / _moveMultiplier);
 		_flyRunSpd = npc.isFlying() ? _runSpd : 0;
 		_flyWalkSpd = npc.isFlying() ? _walkSpd : 0;
+		// A generated look renders as a real player race+sex model, so the client must receive that
+		// race/sex collision size - not the shared base NPC template's - otherwise short races (dwarf)
+		// float above the ground and tall races (orc) sink into it. Falls back to the NPC values when
+		// there is no per-instance look or no matching player template.
+		double collisionRadius = npc.getCollisionRadius();
+		double collisionHeight = npc.getCollisionHeight();
+		if (_look != null)
+		{
+			final PlayerTemplate playerTemplate = PlayerTemplateData.getInstance().getTemplate(_look.getPlayerClass());
+			if (playerTemplate != null)
+			{
+				collisionRadius = _look.isFemale() ? playerTemplate.getFCollisionRadiusFemale() : playerTemplate.getFCollisionRadius();
+				collisionHeight = _look.isFemale() ? playerTemplate.getFCollisionHeightFemale() : playerTemplate.getFCollisionHeight();
+			}
+		}
+		_collisionRadius = collisionRadius;
+		_collisionHeight = collisionHeight;
 		_fpcHolder = npc.getTemplate().getFakePlayerInfo();
 		_clan = _look != null ? null : ClanTable.getInstance().getClan(_fpcHolder.getClanId());
 	}
@@ -144,8 +165,8 @@ public class FakePlayerInfo extends ServerPacket
 		buffer.writeInt(_flyWalkSpd);
 		buffer.writeDouble(_moveMultiplier);
 		buffer.writeDouble(_attackSpeedMultiplier);
-		buffer.writeDouble(_npc.getCollisionRadius());
-		buffer.writeDouble(_npc.getCollisionHeight());
+		buffer.writeDouble(_collisionRadius);
+		buffer.writeDouble(_collisionHeight);
 		buffer.writeInt(_look != null ? _look.getHairStyle() : _fpcHolder.getHair());
 		buffer.writeInt(_look != null ? _look.getHairColor() : _fpcHolder.getHairColor());
 		buffer.writeInt(_look != null ? _look.getFace() : _fpcHolder.getFace());


### PR DESCRIPTION
- Gear fake players and phantoms by class archetype (armor family + weapon), sourced from the GM shop buy-lists as an allow-list; add MONK role and complete gloves/boots/helm slots.
- Bots now wear matching armor SETS with phantom jewelry, and no longer spawn naked when a grade lacks a set.
- Fix fake-player NPCs floating (dwarves) and sinking (orcs) into the ground: FakePlayerInfo now sends the rendered race/sex player collision height instead of the shared base NPC template's.