### PR TITLE
Buffer fixes

### DIFF
--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatManager.java
@@ -589,11 +589,21 @@ public class FakePlayerChatManager implements IXmlReader
 		// LFM/LFP: a real player looking for party members. Parse the wanted roles and recruit a party that walks
 		// over (works brain-off via keywords; with the brain online a free-form call is classified for its roles).
 		// On a recruit we do NOT also run plain shout banter - the answer IS the bots showing up.
-		final List<Recruit> roles = parseLfp(text);
+		final List<String> unresolved = new ArrayList<>();
+		final List<Recruit> roles = parseLfp(text, unresolved);
 		final int wantedLevel = parseLfpLevel(text); // optional "lvl 57"; 0 = match the recruiter's level
 		if (!roles.isEmpty())
 		{
 			PhantomPartyManager.getInstance().recruitFromShout(speaker, roles, wantedLevel);
+			if (!unresolved.isEmpty())
+			{
+				whisperRecruitClarification(speaker, unresolved); // recruited what we could read; ask about the garbled one(s)
+			}
+			return;
+		}
+		if (!unresolved.isEmpty())
+		{
+			whisperRecruitClarification(speaker, unresolved); // a party call whose class word(s) we couldn't read - ask, don't spawn a default
 			return;
 		}
 		if (looksLikeLfp(text))
@@ -634,35 +644,81 @@ public class FakePlayerChatManager implements IXmlReader
 		return FakePlayerChatParsing.parseLfpLevel(text);
 	}
 
-	// Specific occupations a player can request by name ("shillien elder", "gladiator"), longest-first so a
-	// multi-word class wins over a shorter substring, with a combined word-boundary pattern to match them.
+	// Specific occupations a player can request by name ("shillien elder", "gladiator") OR by community alias
+	// ("se", "wc", "ee"). An alias resolves to the EXACT class it means, so "lfm se" spawns a Shillien Elder and
+	// "lfm wc" a Warcryer instead of the role's default class (an Elven Elder / a Prophet) - the tester's "aliases
+	// give the wrong mob" bug. Matched longest-first so a multi-word class wins over a shorter substring.
 	private static final Map<String, PlayerClass> CLASS_BY_NAME = new LinkedHashMap<>();
 	private static final Pattern CLASS_PATTERN;
+	// Single-word class names/aliases a one-typo fuzzy match may correct to, restricted to the DISTINCTIVE ones
+	// (6+ letters) so an ordinary shout word is never mistaken for a class: e.g. "party"/"more"/"danger"/"fast"
+	// stay clear of "pally"/"muse"/"dancer"/"fist". Generic role words ("tank", "dd", "healer") are matched only
+	// exactly by PartyRole.fromToken - they are short, common, and easy to type, and fuzzing them collides with
+	// everyday words. Multi-word class names ("shillien elder") are matched only exactly, by CLASS_PATTERN.
+	private static final Set<String> CLASS_FUZZY;
 	static
 	{
-		final List<PlayerClass> classes = new ArrayList<>();
 		for (PlayerClass pc : PlayerClass.values())
 		{
 			if (PhantomManager.isSelectableClass(pc)) // 2nd+ occupations only; base/1st fall through to role tokens
 			{
-				classes.add(pc);
+				CLASS_BY_NAME.put(pc.name().toLowerCase().replace('_', ' '), pc);
 			}
 		}
-		classes.sort((a, b) -> Integer.compare(b.name().length(), a.name().length()));
+		// Community aliases -> the exact class they name (the value must be a full-name key added just above).
+		putClassAlias("pp", "prophet");
+		putClassAlias("wc", "warcryer");
+		putClassAlias("dc", "doomcryer");
+		putClassAlias("ol", "overlord");
+		putClassAlias("dom", "dominator");
+		putClassAlias("ee", "elder"); // Elven Elder
+		putClassAlias("se", "shillien elder");
+		putClassAlias("shil", "shillien elder");
+		putClassAlias("shillien", "shillien elder"); // in a support call "shillien" reads as Shillien Elder
+		putClassAlias("bp", "bishop");
+		putClassAlias("bish", "bishop");
+		putClassAlias("card", "cardinal");
+		putClassAlias("hiero", "hierophant");
+		putClassAlias("eva", "eva saint");
+		putClassAlias("evas", "eva saint");
+		putClassAlias("muse", "sword muse");
+		putClassAlias("sws", "swordsinger");
+		putClassAlias("bd", "bladedancer");
+		putClassAlias("spectral", "spectral dancer");
+		// Build the exact-match pattern from every key (names + aliases), longest first so a multi-word class wins
+		// over a shorter substring. Trailing "s?" so a plural request ("2 bishops", "3 hawkeyes") still matches.
+		final List<String> keys = new ArrayList<>(CLASS_BY_NAME.keySet());
+		keys.sort((a, b) -> Integer.compare(b.length(), a.length()));
 		final StringBuilder sb = new StringBuilder();
-		for (PlayerClass pc : classes)
+		for (String key : keys)
 		{
-			final String name = pc.name().toLowerCase().replace('_', ' ');
-			CLASS_BY_NAME.put(name, pc);
 			if (sb.length() > 0)
 			{
 				sb.append('|');
 			}
-			sb.append(Pattern.quote(name));
+			sb.append(Pattern.quote(key));
 		}
-		// Trailing "s?" so a plural class request ("2 bishops", "3 hawkeyes") still matches the class by name instead
-		// of falling through to the generic role token (which would spawn the default class, e.g. an Elven Elder).
 		CLASS_PATTERN = Pattern.compile("\\b(" + sb + ")s?\\b", Pattern.CASE_INSENSITIVE);
+		// Fuzzy targets: distinctive single-word class keys/aliases only (6+ letters).
+		final Set<String> fuzzy = new HashSet<>();
+		for (String key : CLASS_BY_NAME.keySet())
+		{
+			if ((key.indexOf(' ') < 0) && (key.length() >= 6))
+			{
+				fuzzy.add(key);
+			}
+		}
+		CLASS_FUZZY = Set.copyOf(fuzzy);
+	}
+
+	/** Registers a community alias -&gt; the class named by an existing full-name key (no-op if the name is unknown). */
+	private static void putClassAlias(String alias, String canonicalName)
+	{
+		final PlayerClass pc = CLASS_BY_NAME.get(canonicalName);
+		if (pc != null)
+		{
+			CLASS_BY_NAME.put(alias, pc);
+		}
 	}
 
 	/**
@@ -670,7 +726,7 @@ public class FakePlayerChatManager implements IXmlReader
 	 * elder") become that exact class; generic role words ("2 dd + healer") become level-appropriate roles.
 	 * Numbers before a class/role repeat it. Empty when the line is not an explicit party call.
 	 */
-	private static List<Recruit> parseLfp(String text)
+	private static List<Recruit> parseLfp(String text, List<String> unresolvedOut)
 	{
 		final List<Recruit> recruits = new ArrayList<>();
 		if (!looksLikeLfp(text))
@@ -699,25 +755,95 @@ public class FakePlayerChatManager implements IXmlReader
 			}
 		}
 
-		// Phase 2: generic role words on whatever text is left. The pure counting state machine (level-token
-		// skipping, per-word counts) lives in FakePlayerChatParsing; here we just resolve each token to a role.
+		// Phase 2: generic role words + one-typo tolerance on whatever text is left. The pure counting state machine
+		// (level-token skipping, per-word counts) lives in FakePlayerChatParsing; here we resolve each token to a
+		// class/role, forgive a single typo, and collect the ones that look like a garbled class so the caller can
+		// ask instead of silently spawning a wrong default.
 		for (FakePlayerChatParsing.RoleRequest request : FakePlayerChatParsing.parseRoleRequests(working.toString()))
 		{
-			// Match the word, falling back to its singular so plurals work ("2 mages", "2 healers", "tanks").
-			PartyRole role = PartyRole.fromToken(request.token);
-			if ((role == null) && (request.token.length() > 1) && request.token.endsWith("s"))
-			{
-				role = PartyRole.fromToken(request.token.substring(0, request.token.length() - 1));
-			}
-			if (role != null)
+			final Recruit resolved = resolveRecruitToken(request.token);
+			if (resolved != null)
 			{
 				for (int i = 0; (i < request.count) && (recruits.size() < 8); i++)
 				{
-					recruits.add(new Recruit(role, 0)); // 0 = the role's default level-appropriate class
+					recruits.add(resolved);
 				}
 			}
+			else if ((unresolvedOut != null) && looksLikeGarbledClass(request.token))
+			{
+				unresolvedOut.add(request.token); // close to a class/role but too garbled to be sure - ask, don't guess
+			}
+			// else: an ordinary non-role word ("cruma", "pls", "for") - ignore silently as before
 		}
 		return recruits;
+	}
+
+	/**
+	 * Resolves one phase-2 recruit token to a specific recruit: an exact class name/alias (spawns that class), an
+	 * exact generic role word (spawns the role's default class), or a single-typo correction of either. Plurals
+	 * fall back to their singular. Returns {@code null} when the word names no class/role - the caller decides
+	 * whether it is a garbled class worth a clarification, or just noise.
+	 */
+	private static Recruit resolveRecruitToken(String token)
+	{
+		// Exact class name/alias (phase 1 blanks these, but a plural or an alias by punctuation can survive).
+		PlayerClass pc = classByNameOrSingular(token);
+		if (pc != null)
+		{
+			return new Recruit(PhantomManager.roleForClass(pc), pc.getId());
+		}
+		// Exact generic role word.
+		PartyRole role = roleByTokenOrSingular(token);
+		if (role != null)
+		{
+			return new Recruit(role, 0); // 0 = the role's default level-appropriate class
+		}
+		// One-typo correction against the distinctive class names ("warcyer" -> "warcryer", "bishpo" -> "bishop").
+		final String near = FakePlayerChatParsing.nearestWithin(token, CLASS_FUZZY, FakePlayerChatParsing.fuzzyBudget(token.length()));
+		if (near != null)
+		{
+			pc = CLASS_BY_NAME.get(near);
+			if (pc != null)
+			{
+				return new Recruit(PhantomManager.roleForClass(pc), pc.getId());
+			}
+		}
+		return null;
+	}
+
+	private static PlayerClass classByNameOrSingular(String token)
+	{
+		PlayerClass pc = CLASS_BY_NAME.get(token);
+		if ((pc == null) && (token.length() > 1) && token.endsWith("s"))
+		{
+			pc = CLASS_BY_NAME.get(token.substring(0, token.length() - 1));
+		}
+		return pc;
+	}
+
+	private static PartyRole roleByTokenOrSingular(String token)
+	{
+		PartyRole role = PartyRole.fromToken(token);
+		if ((role == null) && (token.length() > 1) && token.endsWith("s"))
+		{
+			role = PartyRole.fromToken(token.substring(0, token.length() - 1));
+		}
+		return role;
+	}
+
+	/**
+	 * @return {@code true} if an unresolved token is close enough to a distinctive class name to be a garbled
+	 *         request worth a clarification whisper (rather than an ordinary word in the shout) - within one edit
+	 *         over the auto-correct budget of a 6+ letter class name. Ordinary shout words ("party", "more",
+	 *         "danger") stay clear of the distinctive class set, so they never trigger a spurious "which class?".
+	 */
+	private static boolean looksLikeGarbledClass(String token)
+	{
+		if ((token == null) || (token.length() < 4))
+		{
+			return false; // too short to tell a typo'd class from an ordinary word
+		}
+		return FakePlayerChatParsing.minDistance(token, CLASS_FUZZY) <= (FakePlayerChatParsing.fuzzyBudget(token.length()) + 1);
 	}
 
 	/** @return the count number immediately before position {@code pos} in the text (e.g. "2 dd" -> 2), else 1. */
@@ -744,6 +870,95 @@ public class FakePlayerChatManager implements IXmlReader
 			}
 		}
 		return recruits;
+	}
+
+	/**
+	 * A nearby fake player whispers the recruiter to clarify the class word(s) the recruit parser couldn't read,
+	 * rather than silently spawning the wrong "default" class. Handles the mixed case too: when a shout asked for
+	 * several classes and only one or two were garbled, the readable ones are already being recruited and this only
+	 * asks about the rest. Rate-limited like other public bot chatter; if no fake player is around to voice it, a
+	 * plain "Party" system whisper still gives the player an answer.
+	 */
+	private void whisperRecruitClarification(Player speaker, List<String> tokens)
+	{
+		if ((speaker == null) || (tokens == null) || tokens.isEmpty() || (MESSAGES_THIS_MINUTE.get() >= MAX_MESSAGES_PER_MINUTE))
+		{
+			return;
+		}
+		final String line = recruitClarifyLine(tokens);
+		final Npc voice = pickShoutResponder(speaker);
+		MESSAGES_THIS_MINUTE.incrementAndGet();
+		if (voice != null)
+		{
+			sendChat(speaker, voice.getName(), line); // reuses the length-scaled "typing" whisper path
+		}
+		else
+		{
+			speaker.sendPacket(new CreatureSay(speaker, ChatType.WHISPER, "Party", line));
+		}
+	}
+
+	/** Builds the clarification line naming the class word(s) that couldn't be read (de-duped, at most three). */
+	private static String recruitClarifyLine(List<String> tokens)
+	{
+		final List<String> shown = new ArrayList<>();
+		for (String token : tokens)
+		{
+			if (!shown.contains(token))
+			{
+				shown.add(token);
+			}
+			if (shown.size() >= 3)
+			{
+				break;
+			}
+		}
+		if (shown.size() == 1)
+		{
+			return "which class did you want? didn't catch '" + shown.get(0) + "'";
+		}
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < shown.size(); i++)
+		{
+			if (i > 0)
+			{
+				sb.append((i == (shown.size() - 1)) ? " or " : ", ");
+			}
+			sb.append('\'').append(shown.get(i)).append('\'');
+		}
+		return "which classes did you want? didn't catch " + sb;
+	}
+
+	/** Picks a fake player to voice a recruit clarification: one near the recruiter, else any online fake player. */
+	private Npc pickShoutResponder(Player speaker)
+	{
+		final String speakerName = speaker.getName();
+		final List<Npc> near = new ArrayList<>();
+		World.getInstance().forEachVisibleObjectInRange(speaker, Npc.class, SOCIAL_RANGE, npc ->
+		{
+			if (npc.isFakePlayer() && !isStoreVendor(npc) && !npc.getName().equals(speakerName))
+			{
+				near.add(npc);
+			}
+		});
+		if (!near.isEmpty())
+		{
+			return near.get(Rnd.get(near.size()));
+		}
+		final List<Npc> all = new ArrayList<>();
+		final Set<String> seen = new HashSet<>();
+		for (WorldObject object : World.getInstance().getVisibleObjects())
+		{
+			if (object.isNpc())
+			{
+				final Npc npc = object.asNpc();
+				if (npc.isFakePlayer() && !isStoreVendor(npc) && !npc.getName().equals(speakerName) && seen.add(npc.getName()))
+				{
+					all.add(npc);
+				}
+			}
+		}
+		return all.isEmpty() ? null : all.get(Rnd.get(all.size()));
 	}
 
 	/**

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatParsing.java
@@ -222,6 +222,126 @@ public final class FakePlayerChatParsing
 	}
 
 	/**
+	 * Optimal string alignment (Damerau-Levenshtein) distance between two lowercase tokens: insert, delete,
+	 * substitute and adjacent transposition each cost 1. Used to forgive a single typo in a recruited class/role
+	 * token, so "warcyer" -&gt; "warcryer" and "bishpo" -&gt; "bishop" still resolve.
+	 * @return the edit distance, or {@link Integer#MAX_VALUE} if either input is {@code null}
+	 */
+	public static int editDistance(String a, String b)
+	{
+		if ((a == null) || (b == null))
+		{
+			return Integer.MAX_VALUE;
+		}
+		final int la = a.length();
+		final int lb = b.length();
+		if (la == 0)
+		{
+			return lb;
+		}
+		if (lb == 0)
+		{
+			return la;
+		}
+		int[] prevPrev = new int[lb + 1];
+		int[] prev = new int[lb + 1];
+		int[] curr = new int[lb + 1];
+		for (int j = 0; j <= lb; j++)
+		{
+			prev[j] = j;
+		}
+		for (int i = 1; i <= la; i++)
+		{
+			curr[0] = i;
+			final char ca = a.charAt(i - 1);
+			for (int j = 1; j <= lb; j++)
+			{
+				final char cb = b.charAt(j - 1);
+				final int cost = (ca == cb) ? 0 : 1;
+				int v = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+				if ((i > 1) && (j > 1) && (ca == b.charAt(j - 2)) && (a.charAt(i - 2) == cb))
+				{
+					v = Math.min(v, prevPrev[j - 2] + 1); // adjacent transposition ("bishpo" <-> "bishop")
+				}
+				curr[j] = v;
+			}
+			final int[] tmp = prevPrev;
+			prevPrev = prev;
+			prev = curr;
+			curr = tmp;
+		}
+		return prev[lb];
+	}
+
+	/**
+	 * The edit-distance budget that still counts as "the same word" for a token of this length: exact for very
+	 * short tokens (so 2-3 letter aliases like "pp"/"dd" are never fuzzy-matched to something else), one typo for
+	 * normal words, two for long class names.
+	 */
+	public static int fuzzyBudget(int tokenLength)
+	{
+		if (tokenLength <= 3)
+		{
+			return 0;
+		}
+		if (tokenLength <= 7)
+		{
+			return 1;
+		}
+		return 2;
+	}
+
+	/** @return the smallest edit distance from {@code token} to any candidate, or {@link Integer#MAX_VALUE} if none. */
+	public static int minDistance(String token, Iterable<String> candidates)
+	{
+		int best = Integer.MAX_VALUE;
+		if (candidates != null)
+		{
+			for (String c : candidates)
+			{
+				final int d = editDistance(token, c);
+				if (d < best)
+				{
+					best = d;
+				}
+			}
+		}
+		return best;
+	}
+
+	/**
+	 * The single closest candidate to {@code token}, if it is within {@code maxDistance} AND unambiguous - a lone
+	 * best. A tie between two different candidates returns {@code null} so the caller asks rather than guessing the
+	 * wrong class.
+	 * @return the closest candidate, or {@code null} if none is within budget or the best is a tie
+	 */
+	public static String nearestWithin(String token, Iterable<String> candidates, int maxDistance)
+	{
+		if ((token == null) || (candidates == null) || (maxDistance < 0))
+		{
+			return null;
+		}
+		String best = null;
+		int bestDist = Integer.MAX_VALUE;
+		boolean tie = false;
+		for (String c : candidates)
+		{
+			final int d = editDistance(token, c);
+			if (d < bestDist)
+			{
+				bestDist = d;
+				best = c;
+				tie = false;
+			}
+			else if ((d == bestDist) && !c.equals(best))
+			{
+				tie = true;
+			}
+		}
+		return ((best == null) || (bestDist > maxDistance) || tie) ? null : best;
+	}
+
+	/**
 	 * Canonicalise a free-text meet spot (and its common aliases) to one of a fixed set of destinations.
 	 * @param spot the raw spot from a {@code [[MEET:spot]]} tag
 	 * @return one of "gatekeeper", "warehouse", "shop", or "cancel"; unknown/blank spots default to "gatekeeper"

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuddyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuddyManager.java
@@ -1222,13 +1222,27 @@ public class PhantomBuddyManager implements IXmlReader
 			{
 				continue;
 			}
-			final BuffInfo info = target.getEffectList().getBuffInfoBySkillId(buff.getId());
-			if ((info == null) || (info.getTime() <= BUFF_REFRESH_SECONDS))
+			// Presence keys on the abnormal SLOT + LEVEL, not the skill id - see PhantomBuffs.needsBuff. This stops a
+			// buddy looping on a buff it cannot land: a shared slot already held by another buffer's skill, or a
+			// STRONGER effect (a P.Atk herb over a low-level Might) the engine would reject our cast over. A weaker
+			// occupant is upgraded; an equal one is refreshed near expiry. Chant of Life is exempt - it is the
+			// HP-gated HoT keyed on its own id (the HP gate just above already decided it is wanted).
+			final boolean need = (buff.getId() == CHANT_OF_LIFE_ID) //
+				? isExpiringById(target, buff.getId()) //
+				: PhantomBuffs.needsBuff(target, buff, BUFF_REFRESH_SECONDS);
+			if (need)
 			{
 				return buff;
 			}
 		}
 		return null;
+	}
+
+	/** Chant of Life is keyed on its own id (an HP-gated HoT): {@code true} if it is missing or about to expire. */
+	private static boolean isExpiringById(Player target, int skillId)
+	{
+		final BuffInfo info = target.getEffectList().getBuffInfoBySkillId(skillId);
+		return (info == null) || (info.getTime() <= BUFF_REFRESH_SECONDS);
 	}
 
 	/**

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffs.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomBuffs.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 import org.l2jmobius.gameserver.data.xml.SkillData;
 import org.l2jmobius.gameserver.model.actor.Player;
+import org.l2jmobius.gameserver.model.skill.AbnormalType;
+import org.l2jmobius.gameserver.model.skill.BuffInfo;
 import org.l2jmobius.gameserver.model.skill.Skill;
 
 /**
@@ -59,9 +61,12 @@ public final class PhantomBuffs
 	// cap, and because the engine evicts the OLDEST buff on each new cast, the buffer rotated through the whole kit
 	// forever (the endless re-buff loop a low-level buffer never hit, because its short kit fit). So the buffer keeps
 	// only this fixed core that fits comfortably; the situational / consumable "greater" buffs and the resistances
-	// are cast ONLY when the player asks for them by name (see requestedBuff / "<buff> on <name>"). Class variants
-	// are listed so the same plan works for Prophet / Elder / Warcryer.
-	private static final Set<Integer> AUTO_COMMON = Set.of(1204, 4342, 4391); // Wind Walk
+	// are cast ONLY when the player asks for them by name (see requestedBuff / "<buff> on <name>"). Each buff's class
+	// variants are listed so one plan covers every buffer class: Prophet / Elder (1xxx + 43xx/44xx variants) AND the
+	// Orc buffers, which are REAL classes when recruited - the Warcryer/Doomcryer "Chant of ..." set and the Overlord/
+	// Dominator "Pa'agrio" set (added at the end of AUTO_MELEE/AUTO_CASTER; without them an Orc buffer buffed nothing).
+	private static final Set<Integer> AUTO_COMMON = Set.of(1204, 4342, 4391, // Wind Walk
+		1282); // Pa'agrian Haste (Overlord's run-speed buff - its Wind Walk equivalent)
 	private static final Set<Integer> AUTO_MELEE = Set.of( //
 		1086, 4357, 4402, // Haste
 		1068, 4345, 4393, // Might (base; Greater Might is on request only - it shares a slot with Greater Shield)
@@ -78,7 +83,32 @@ public final class PhantomBuffs
 		1036, // Magic Barrier
 		1045, // Blessed Body
 		1048, // Blessed Soul
-		1062, 4352, 4397); // Berserker Spirit
+		1062, 4352, 4397, // Berserker Spirit
+		// Warcryer / Doomcryer chants. A recruited Warcryer is a REAL Warcryer (class 52, a selectable 2nd class),
+		// not a Prophet, so its buff kit is the "Chant of ..." family - a wholly different id set the buffer loop
+		// otherwise never recognised (it said "rebuffing" and cast nothing). These are the physical/melee chants:
+		1007, // Chant of Battle (P.Atk)
+		1251, // Chant of Fury (atk. speed)
+		1253, // Chant of Rage (crit damage)
+		1308, // Chant of Predator (crit rate)
+		1309, // Chant of Eagle (accuracy)
+		1310, // Chant of Vampire (vampiric attack)
+		1390, // War Chant (P.Atk / P.Def)
+		// Warcryer chants that help everyone (also listed under AUTO_CASTER):
+		1006, // Chant of Fire (M.Def)
+		1009, // Chant of Shielding (P.Def)
+		1391, // Earth Chant (P.Def)
+		1252, // Chant of Evasion (evasion)
+		1284, // Chant of Revenge (damage reflect)
+		// Overlord "Pa'agrio" chants (Overlord = class 51, also a real class recruited as a buffer). Physical set:
+		1003, // Pa'agrian Gift (P.Atk)
+		1249, // The Vision of Pa'agrio (accuracy)
+		1250, // Under the Protection of Pa'agrio (shield block rate)
+		1261, // The Rage of Pa'agrio (all-round power buff)
+		// Overlord chants that help everyone (also listed under AUTO_CASTER):
+		1005, // Blessings of Pa'agrio (P.Def)
+		1008, // The Glory of Pa'agrio (M.Def)
+		1260); // The Tact of Pa'agrio (evasion)
 	private static final Set<Integer> AUTO_CASTER = Set.of( //
 		1085, 4355, 4400, // Acumen
 		1059, 4356, 4401, // Empower (base; Greater Empower is on request only)
@@ -91,7 +121,20 @@ public final class PhantomBuffs
 		1036, // Magic Barrier
 		1045, // Blessed Body
 		1048, // Blessed Soul
-		1062); // Berserker Spirit
+		1062, // Berserker Spirit
+		// Warcryer / Doomcryer chants a caster wants (see the melee list for why these are needed):
+		1002, // Flame Chant (casting speed)
+		1006, // Chant of Fire (M.Def)
+		1009, // Chant of Shielding (P.Def survivability)
+		1391, // Earth Chant (P.Def)
+		1252, // Chant of Evasion (evasion)
+		1284, // Chant of Revenge (damage reflect)
+		// Overlord "Pa'agrio" chants a caster wants:
+		1004, // The Wisdom of Pa'agrio (casting speed)
+		1261, // The Rage of Pa'agrio (all-round power buff)
+		1005, // Blessings of Pa'agrio (P.Def survivability)
+		1008, // The Glory of Pa'agrio (M.Def)
+		1260); // The Tact of Pa'agrio (evasion)
 
 	private static final Set<Integer> WIND_WALK = Set.of(1204, 4342, 4391);
 	private static final Set<Integer> ACUMEN = Set.of(1085, 4355, 4400);
@@ -259,6 +302,53 @@ public final class PhantomBuffs
 				return AUTO_COMMON.contains(skillId) || (targetIsCaster ? AUTO_CASTER.contains(skillId) : AUTO_MELEE.contains(skillId));
 			}
 		}
+	}
+
+	/**
+	 * Decides whether {@code buff} should be (re)cast on {@code target} right now, respecting the engine's abnormal
+	 * stacking so a support never loops on a buff it cannot land. The presence test keys on the buff's abnormal
+	 * SLOT, not its skill id (different buffer classes fill one slot with different skills), and it compares abnormal
+	 * LEVELS so a stronger effect already in the slot is left alone instead of being re-cast forever - e.g. a P.Atk
+	 * herb (Herb of Power, abnormalLevel 3) blocks a level-25 buffer's Might (abnormalLevel 2), so we skip Might
+	 * until the herb fades rather than hammering a cast the engine keeps rejecting (the tester's "buffer casts the
+	 * same buff over and over" bug). Rules:
+	 * <ul>
+	 * <li>slot empty -&gt; cast;</li>
+	 * <li>slot held by a WEAKER effect (lower abnormal level) -&gt; cast, to upgrade it;</li>
+	 * <li>slot held by a STRONGER effect (higher abnormal level) -&gt; skip, our cast would be rejected;</li>
+	 * <li>slot held by an equal-level effect -&gt; recast only when it is about to expire ({@code <= refreshSeconds}).</li>
+	 * </ul>
+	 * A slotless buff ({@code abnormalType} NONE) stacks independently, so it keys on its own skill id as before.
+	 * @param target the buff target
+	 * @param buff the buff the support is considering
+	 * @param refreshSeconds recast an equal-or-weaker slot when it has this many seconds or fewer left
+	 * @return {@code true} if the buff should be cast now
+	 */
+	public static boolean needsBuff(Player target, Skill buff, int refreshSeconds)
+	{
+		final AbnormalType slot = buff.getAbnormalType();
+		if ((slot == null) || slot.isNone())
+		{
+			// Slotless buff: independent stack, key on the skill's own id.
+			final BuffInfo info = target.getEffectList().getBuffInfoBySkillId(buff.getId());
+			return (info == null) || (info.getTime() <= refreshSeconds);
+		}
+		final BuffInfo info = target.getEffectList().getBuffInfoByAbnormalType(slot);
+		if (info == null)
+		{
+			return true; // slot free
+		}
+		final int have = info.getSkill().getAbnormalLevel();
+		final int want = buff.getAbnormalLevel();
+		if (have > want)
+		{
+			return false; // a stronger effect holds the slot - our cast would be rejected; never loop on it
+		}
+		if (have < want)
+		{
+			return true; // upgrade the weaker effect in the slot
+		}
+		return info.getTime() <= refreshSeconds; // same strength: only refresh when it is about to drop
 	}
 
 	/**

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -169,29 +169,62 @@ public class PhantomPartyManager
 
 	// Class competence (party plan Bucket 2): songs/dances, archer discipline, tank panic button, dagger
 	// positioning, DPS aggro-easing, nuker crowd control.
-	// SWS/BD keep their 2-minute songs/dances running (the whole point of bringing one - and legitimate to
-	// maintain mid-raid, unlike 20-minute buffs). A member re-sings when its own copy of the effect has this
-	// little time left; the rotation is capped because each cast is ~60 MP and 2.5s of not fighting.
+	// SWS/BD keep their FULL learned song/dance kit running (the whole point of bringing one - and legitimate to
+	// maintain mid-raid, unlike 20-minute buffs). A member re-sings when its own copy of the effect has this little
+	// time left. The rotation is no longer pinned to a fixed 3: songs and dances share the target's 12-slot music
+	// pool (MaxDanceAmount), so resolveSongs caps a member to its SHARE of that pool (see songRotationCap) - a SwS
+	// and a BD in the same party split it instead of evicting each other's music in an endless re-cast loop.
 	private static final int SONG_REFRESH_SECONDS = 15;
-	private static final int SONG_ROTATION_MAX = 3;
+	private static final int MUSIC_POOL_SLOTS = 12; // MaxDanceAmount: songs + dances share one 12-slot pool per target
+	// All Interlude songs are party buffs, so the singer auto-maintains every one it has learned (best-value first;
+	// resolveSongs filters to what it actually knows). A specific song can also be asked for by name (requestedSong).
 	private static final int[] SINGER_SONGS =
 	{
-		269, // Song of Hunter (crit rate - lvl 49)
-		264, // Song of Earth (p.def - lvl 55)
-		304, // Song of Vitality (max HP - lvl 66)
-		267 // Song of Warding (m.def - lvl 40)
+		269, // Song of Hunter (crit rate)
+		264, // Song of Earth (p.def)
+		304, // Song of Vitality (max HP)
+		267, // Song of Warding (m.def)
+		268, // Song of Wind (speed)
+		305, // Song of Vengeance (damage reflect)
+		270, // Song of Invocation (max MP)
+		265, // Song of Life (HP regen)
+		306, // Song of Flame Guard (fire resist)
+		308, // Song of Storm Guard (wind resist)
+		266, // Song of Water (water resist)
+		349, // Song of Renewal (shorter re-use/cast penalties)
+		363, // Song of Meditation (MP regen)
+		364 // Song of Champion (P.Atk / Atk. speed)
 	};
+	// Bladedancer dances, melee-comp order. Party-beneficial dances only: the self-only Siren's Dance (365) and
+	// Dance of Shadows (366, silent-move), and the offensive Dance of Medusa (367, enemy petrify), are left OUT of
+	// the auto rotation - they are still castable on an explicit by-name request (requestedSong).
 	private static final int[] DANCER_DANCES =
 	{
-		275, // Dance of Fury (atk. speed - lvl 58)
-		271, // Dance of the Warrior (p.atk - lvl 55)
-		274 // Dance of Fire (crit damage - lvl 40)
+		275, // Dance of Fury (atk. speed)
+		271, // Dance of the Warrior (p.atk)
+		274, // Dance of Fire (crit damage)
+		310, // Dance of the Vampire (HP drain on hit)
+		276, // Dance of Concentration (cast speed)
+		273, // Dance of the Mystic (m.atk)
+		272, // Dance of Inspiration (bow power)
+		277, // Dance of Light
+		311, // Dance of Protection
+		307, // Dance of Aqua Guard (water resist)
+		309 // Dance of Earth Guard (earth resist)
 	};
 	private static final int[] DANCER_DANCES_MAGE = // mage-heavy comp: feed the casters first
 	{
-		273, // Dance of the Mystic (m.atk - lvl 49)
-		276, // Dance of Concentration (cast speed - lvl 52)
-		275 // Dance of Fury
+		273, // Dance of the Mystic (m.atk)
+		276, // Dance of Concentration (cast speed)
+		275, // Dance of Fury (atk. speed)
+		271, // Dance of the Warrior (p.atk)
+		274, // Dance of Fire (crit damage)
+		310, // Dance of the Vampire (HP drain on hit)
+		272, // Dance of Inspiration (bow power)
+		277, // Dance of Light
+		311, // Dance of Protection
+		307, // Dance of Aqua Guard (water resist)
+		309 // Dance of Earth Guard (earth resist)
 	};
 	// TANK panic button: Ultimate Defense, hand-cast at low HP while still being hit - instead of the AutoUse
 	// auto-buff loop burning it the moment it's off cooldown (it's a SELF-target buff, so registerAutoSkills
@@ -350,9 +383,10 @@ public class PhantomPartyManager
 		long moveDelayUntil; // the pending start-up stagger; 0 when none
 		int lastDestX; // last formation destination actually issued, to avoid re-pathing to the same spot
 		int lastDestY;
-		List<Skill> songs; // lazy (SINGER/DANCER): the up-to-3 songs/dances this member keeps running
+		List<Skill> songs; // lazy (SINGER/DANCER): the full learned song/dance kit this member keeps running (capped to its music-pool share)
 		boolean songsLookedUp;
 		boolean songsRequested; // explicit "sing"/"dance" order: run the rotation now even out of combat
+		Skill pendingSong; // explicit "<song/dance> by name" order (SINGER/DANCER): cast that exact one next tick, even if it's outside the auto rotation
 		Skill survival; // lazy (TANK): Ultimate Defense, hand-cast at low HP (parked out of the auto-buff loop)
 		boolean survivalLookedUp;
 		Skill cc; // lazy (NUKER): Sleep / Dryad Root for a loose add
@@ -763,6 +797,21 @@ public class PhantomPartyManager
 				{
 					deliver(state, "i don't have " + requested);
 				}
+				return true;
+			}
+		}
+
+		// On-demand SPECIFIC song/dance by name ("sing song of wind", "dance of fire pls", "give me fury"): cast that
+		// exact one next tick, even if it's outside the auto rotation (e.g. Dance of Medusa). Checked BEFORE the
+		// generic "sing"/"dance" trigger below so a named request casts that one song, not the whole rotation. It
+		// resolves against the member's own learned skills, so a singer only answers song names and a dancer dances.
+		if ((state.role == PartyRole.SINGER) || (state.role == PartyRole.DANCER))
+		{
+			final Skill namedSong = requestedSong(state.npc, text);
+			if (namedSong != null)
+			{
+				state.pendingSong = namedSong;
+				deliver(state, ((state.role == PartyRole.SINGER) ? "singing " : "dancing ") + namedSong.getName().toLowerCase());
 				return true;
 			}
 		}
@@ -1513,6 +1562,24 @@ public class PhantomPartyManager
 		if (DEBUG)
 		{
 			LOGGER.info("PARTY-RAID " + line);
+		}
+	}
+
+	/**
+	 * Diagnostic: logs every buff a support phantom actually casts, so we can see exactly what a buffer is doing (and
+	 * spot a re-cast loop, e.g. two different skills fighting over the same abnormal slot). Toggle with the existing
+	 * {@code //phantom debug on|off}. {@code via} says which path issued it (upkeep / rebuff / on-demand).
+	 */
+	private void dbgBuff(Player npc, Player target, Skill buff, String via)
+	{
+		if (DEBUG && (buff != null))
+		{
+			final BuffInfo existing = (target == null) ? null : target.getEffectList().getBuffInfoBySkillId(buff.getId());
+			final BuffInfo slot = ((target == null) || (buff.getAbnormalType() == null)) ? null : target.getEffectList().getBuffInfoByAbnormalType(buff.getAbnormalType());
+			LOGGER.info("PARTY-BUFF " + npc.getName() + " -> " + (target == null ? "?" : target.getName()) //
+				+ " : " + buff.getName() + " (id " + buff.getId() + " lvl " + buff.getLevel() + ", abnormal " + buff.getAbnormalType() + ") [" + via + "]" //
+				+ " | this-buff " + (existing == null ? "absent" : existing.getTime() + "s left") //
+				+ " | abnormal-slot held by " + ((slot == null) ? "nothing" : (slot.getSkill().getName() + " id " + slot.getSkill().getId())));
 		}
 	}
 
@@ -2735,10 +2802,11 @@ public class PhantomPartyManager
 	// ===== Class competence (Bucket 2): songs/dances, panic buttons, discipline, positioning, CC =====
 
 	/**
-	 * SWS/BD song/dance upkeep. Resolves the member's rotation once (the role's priority list filtered to what it
-	 * actually knows, capped at {@value #SONG_ROTATION_MAX} - each cast is ~60 MP and 2.5s of not fighting); then
-	 * each tick the first song whose effect is missing or about to lapse on the member itself is recast on the
-	 * party. Below 2nd class (no songs known yet) this costs nothing after the first lookup.
+	 * SWS/BD song/dance upkeep. First honours any explicit by-name request ({@link Member#pendingSong}); otherwise
+	 * resolves the member's rotation once (the role's priority list filtered to what it actually knows, capped at its
+	 * music-pool share by {@link #songRotationCap}); then each tick the first song whose effect is missing or about
+	 * to lapse on the member itself is recast on the party. Below 2nd class (no songs known yet) this costs nothing
+	 * after the first lookup.
 	 * @return {@code true} if a song is mid-cast or was just fired - the caller skips fighting this tick
 	 */
 	private boolean maintainSongs(Member state)
@@ -2748,6 +2816,28 @@ public class PhantomPartyManager
 			return false;
 		}
 		final Player npc = state.npc;
+		if (npc.isCastingNow())
+		{
+			return true; // a song is mid-cast - don't clobber it with an attack intention
+		}
+		// On-demand SPECIFIC song/dance ("dance of fire pls"): cast it now, in or out of combat, even if it's outside
+		// the auto rotation. Handled before the fight-time gate so a named request lands while resting too.
+		if (state.pendingSong != null)
+		{
+			final Skill song = state.pendingSong;
+			if (castable(npc, song))
+			{
+				if (!readyToCast(npc))
+				{
+					return true; // stand up first; cast next tick (pendingSong kept so the order isn't lost)
+				}
+				state.pendingSong = null;
+				npc.setTarget(npc);
+				npc.doCast(song);
+				return true;
+			}
+			state.pendingSong = null; // can't cast it right now (out of MP / disabled / dancer without duals) - drop it
+		}
 		if (!state.songsLookedUp)
 		{
 			state.songsLookedUp = true;
@@ -2763,10 +2853,6 @@ public class PhantomPartyManager
 		if (!state.songsRequested && !npc.isInCombat() && !((state.owner != null) && state.owner.isInCombat()) && !raidEngaged(state))
 		{
 			return false;
-		}
-		if (npc.isCastingNow())
-		{
-			return true; // a song is mid-cast - don't clobber it with an attack intention
 		}
 		for (Skill song : state.songs)
 		{
@@ -2788,9 +2874,10 @@ public class PhantomPartyManager
 
 	/**
 	 * The songs/dances this member will keep running: its role's priority list (dancers feed the casters first in
-	 * a mage-heavy comp), filtered to what it actually knows, capped at {@value #SONG_ROTATION_MAX}. A dancer
-	 * holding anything but dual swords gets no rotation at all - every dance hard-requires equipped duals
-	 * ({@code <using kind="DUAL"/>}), so trying would just wedge it in a rejected-cast loop instead of fighting.
+	 * a mage-heavy comp), filtered to what it actually knows, capped at its share of the music pool (see
+	 * {@link #songRotationCap}). A dancer holding anything but dual swords gets no rotation at all - every dance
+	 * hard-requires equipped duals ({@code <using kind="DUAL"/>}), so trying would just wedge it in a rejected-cast
+	 * loop instead of fighting.
 	 */
 	private List<Skill> resolveSongs(Member state)
 	{
@@ -2809,6 +2896,7 @@ public class PhantomPartyManager
 		{
 			priority = SINGER_SONGS;
 		}
+		final int cap = songRotationCap(state);
 		final List<Skill> songs = new ArrayList<>();
 		for (int id : priority)
 		{
@@ -2816,13 +2904,76 @@ public class PhantomPartyManager
 			if (known != null)
 			{
 				songs.add(known);
-				if (songs.size() >= SONG_ROTATION_MAX)
+				if (songs.size() >= cap)
 				{
 					break;
 				}
 			}
 		}
 		return songs;
+	}
+
+	/**
+	 * How many songs/dances this member keeps up automatically: its share of the target's
+	 * {@value #MUSIC_POOL_SLOTS}-slot music pool (MaxDanceAmount). Songs and dances share that one pool and evict
+	 * oldest-first when it overflows, so when the party fields more than one music class (a SwS AND a BD) the pool
+	 * is split between them - otherwise their full rotations would keep evicting each other on shared targets in an
+	 * endless re-cast loop. Solo music class: the whole pool (still bounded by what the member has actually learned,
+	 * which resolveSongs applies). Members are all recruited before the first fight, so this count is stable by the
+	 * time the rotation is resolved.
+	 */
+	private int songRotationCap(Member state)
+	{
+		int musicClasses = 0;
+		for (Member m : _members.values())
+		{
+			if ((m.owner == state.owner) && ((m.role == PartyRole.SINGER) || (m.role == PartyRole.DANCER)))
+			{
+				musicClasses++;
+			}
+		}
+		return Math.max(1, MUSIC_POOL_SLOTS / Math.max(1, musicClasses));
+	}
+
+	/**
+	 * A specific song/dance the message asks for by name, resolved against what this member actually knows (so a
+	 * singer only matches songs and a dancer only dances). Matches the full skill name ("dance of fire") or its
+	 * distinctive word ("fire", "fury", "vampire", "hunter"), so "sing song of wind", "dance of the vampire" and
+	 * "give me fury" all resolve. Longest match wins. Returns {@code null} if the line names no song/dance it knows.
+	 */
+	private static Skill requestedSong(Player npc, String text)
+	{
+		final String message = normalizeWords(text);
+		Skill best = null;
+		int bestLength = 0;
+		for (Skill skill : npc.getAllSkills())
+		{
+			if ((skill == null) || !skill.isDance()) // songs and dances both report isDance() == true
+			{
+				continue;
+			}
+			final String name = normalizeWords(skill.getName()); // e.g. " dance of fire "
+			if (message.contains(name) && (name.length() > bestLength))
+			{
+				best = skill;
+				bestLength = name.length();
+				continue;
+			}
+			// Distinctive tail: drop a leading "song of (the) " / "dance of (the) " so "fire"/"vampire"/"hunter" match.
+			final String tail = normalizeWords(skill.getName().toLowerCase().replaceFirst("^(song|dance) of (the )?", ""));
+			if ((tail.trim().length() >= 4) && message.contains(tail) && (tail.length() > bestLength))
+			{
+				best = skill;
+				bestLength = tail.length();
+			}
+		}
+		return best;
+	}
+
+	/** Lowercases, strips punctuation and collapses whitespace, wrapped in single spaces for whole-word contains-checks. */
+	private static String normalizeWords(String text)
+	{
+		return " " + text.toLowerCase().replaceAll("[^a-z0-9 ]", " ").replaceAll("\\s+", " ").trim() + " ";
 	}
 
 	/** How caster-heavy this party is: a mage leader plus its nuker members (drives the dancer's rotation choice). */
@@ -3248,6 +3399,7 @@ public class PhantomPartyManager
 				{
 					return; // another support (or the buddy) is already landing this exact buff on the target
 				}
+				dbgBuff(npc, target, buff, "on-demand");
 				npc.setTarget(target);
 				npc.doCast(buff);
 				return;
@@ -4039,6 +4191,7 @@ public class PhantomPartyManager
 						continue;
 					}
 					state.rebuffIdx++;
+					dbgBuff(npc, target, buff, "rebuff");
 					npc.setTarget(target);
 					npc.doCast(buff);
 					return true;
@@ -4068,8 +4221,13 @@ public class PhantomPartyManager
 			{
 				continue; // wrong archetype, out of MP, or out of the buff's reagent (don't loop re-casting a buff that will be rejected)
 			}
-			final BuffInfo info = target.getEffectList().getBuffInfoBySkillId(buff.getId());
-			if ((info == null) || (info.getTime() <= BUFF_REFRESH_SECONDS))
+			// Presence keys on the abnormal SLOT + LEVEL, not the skill id - see PhantomBuffs.needsBuff. Different
+			// buffer classes fill one slot with different skills (PD_UP is Shield 1040 / Chant of Shielding 1009 /
+			// Blessings of Pa'agrio 1005), so keying on id looped a mixed-buffer party forever; and a STRONGER effect
+			// already in the slot (a P.Atk herb over a low-level Might) would make an id/any-occupant check re-cast a
+			// buff the engine keeps rejecting. needsBuff skips an equal-or-stronger slot, upgrades a weaker one, and
+			// refreshes near expiry - so no loop, whatever is holding the slot.
+			if (PhantomBuffs.needsBuff(target, buff, BUFF_REFRESH_SECONDS))
 			{
 				if (beingBuffedByAnother(state, target, buff))
 				{
@@ -4083,6 +4241,7 @@ public class PhantomPartyManager
 				{
 					continue; // another bot buffer (party support or the personal buddy) is already landing this exact buff
 				}
+				dbgBuff(npc, target, buff, "upkeep");
 				npc.setTarget(target);
 				npc.doCast(buff);
 				return true;

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/model/actor/holders/creature/EffectList.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/model/actor/holders/creature/EffectList.java
@@ -529,6 +529,34 @@ public class EffectList
 	{
 		stopAndRemove(broadcast, SkillFinishType.REMOVED, info, effects);
 	}
+
+	/**
+	 * Removes the oldest in-use effect from {@code pool} to free a slot for a new one. Buffs and songs/dances are
+	 * trimmed within their OWN pool ({@link #_buffs} or {@link #_dances}) so the two never displace each other.
+	 * @param pool the effect queue to trim
+	 */
+	private void evictOldestInUse(Queue<BuffInfo> pool)
+	{
+		BuffInfo toRemove = null;
+		for (BuffInfo info : pool)
+		{
+			if (!info.isInUse())
+			{
+				continue;
+			}
+
+			// Track the oldest (earliest started) in-use effect to be removed.
+			if ((toRemove == null) || (info.getPeriodStartTicks() < toRemove.getPeriodStartTicks()))
+			{
+				toRemove = info;
+			}
+		}
+
+		if (toRemove != null)
+		{
+			stopAndRemove(true, toRemove, pool);
+		}
+	}
 	
 	/**
 	 * Auxiliary method to stop all effects from a buff info and remove it from an effect list and stacked effects.
@@ -1374,50 +1402,24 @@ public class EffectList
 		// Select the map that holds the effects related to this skill.
 		final Queue<BuffInfo> effects = getEffectList(skill);
 		
-		// Remove first buff when buff list is full.
+		// Remove the oldest effect when a pool is full. Regular buffs and songs/dances have SEPARATE pools in retail
+		// Interlude: 20 buff slots (MaxBuffAmount, +Divine Inspiration) AND a distinct 12 song/dance pool
+		// (MaxDanceAmount), for up to 32 simultaneous effects - not a single shared 20. So a Sword Singer's songs or
+		// a Bladedancer's dances must NOT eat into a buffer's 20 slots (and vice-versa). Each pool is counted and
+		// trimmed on its own: a full buff pool evicts only the oldest buff, a full dance pool only the oldest dance -
+		// they never displace each other.
 		if (!skill.isDebuff() && !skill.isToggle() && !skill.is7Signs() && !doesStack(skill))
 		{
-			final int totalBuffs = getBuffCount() + getDanceCount();
-			final int maxTotalBuffs = _owner.getStat().getMaxBuffCount();
-			final int maxDances = PlayerConfig.DANCES_MAX_AMOUNT;
-			final int currentDances = getDanceCount();
-			if (((totalBuffs >= maxTotalBuffs) && !skill.isHealingPotionSkill()) || (skill.isDance() && (currentDances >= maxDances)))
+			if (skill.isDance())
 			{
-				// New list counting buff and dances/song all together.
-				final List<BuffInfo> allEffects = new ArrayList<>();
-				allEffects.addAll(_buffs);
-				allEffects.addAll(_dances);
-				
-				BuffInfo toRemove = null;
-				for (BuffInfo buffInfo : allEffects)
+				if (getDanceCount() >= PlayerConfig.DANCES_MAX_AMOUNT)
 				{
-					if (!buffInfo.isInUse())
-					{
-						continue;
-					}
-					
-					// Check if limit of dance/song is exceeded.
-					if (skill.isDance() && (currentDances >= maxDances) && !buffInfo.getSkill().isDance())
-					{
-						continue;
-					}
-					
-					// Check the oldest buff to be removed.
-					if ((toRemove == null) || (buffInfo.getPeriodStartTicks() < toRemove.getPeriodStartTicks()))
-					{
-						toRemove = buffInfo;
-					}
+					evictOldestInUse(_dances);
 				}
-				
-				if (toRemove != null)
-				{
-					final Queue<BuffInfo> list = getEffectList(toRemove.getSkill());
-					if (list != null)
-					{
-						list.remove(toRemove);
-						stopAndRemove(true, toRemove, list);
-					}
-				}
+			}
+			else if ((getBuffCount() >= _owner.getStat().getMaxBuffCount()) && !skill.isHealingPotionSkill())
+			{
+				evictOldestInUse(_buffs);
 			}
 		}
 		

--- a/L2J_Mobius_CT_0_Interlude github/tests/java/FakePlayerChatParsingTest.java
+++ b/L2J_Mobius_CT_0_Interlude github/tests/java/FakePlayerChatParsingTest.java
@@ -56,6 +56,7 @@ public class FakePlayerChatParsingTest
 		testShopTagPattern();
 		testCountBefore();
 		testParseRoleRequests();
+		testFuzzyMatching();
 
 		System.out.println();
 		System.out.println("Ran " + checks + " checks, " + failures + " failure(s).");
@@ -179,6 +180,32 @@ public class FakePlayerChatParsingTest
 		// Empty / null inputs are safe.
 		eq(0, FakePlayerChatParsing.parseRoleRequests("").size(), "empty text -> no requests");
 		eq(0, FakePlayerChatParsing.parseRoleRequests(null).size(), "null text -> no requests");
+	}
+
+	private static void testFuzzyMatching()
+	{
+		// Edit distance: identical, empty, and single insert/delete/substitute = 1.
+		eq(0, FakePlayerChatParsing.editDistance("prophet", "prophet"), "identical -> 0");
+		eq(7, FakePlayerChatParsing.editDistance("", "prophet"), "empty vs word -> length");
+		eq(1, FakePlayerChatParsing.editDistance("warcyer", "warcryer"), "missing letter -> 1");
+		eq(1, FakePlayerChatParsing.editDistance("prophrt", "prophet"), "one substitution -> 1");
+		// Adjacent transposition costs 1 (Damerau), so "bishpo" is one typo from "bishop".
+		eq(1, FakePlayerChatParsing.editDistance("bishpo", "bishop"), "adjacent transposition -> 1");
+
+		// Length-scaled budget: short aliases are exact-only, longer names forgive one/two typos.
+		eq(0, FakePlayerChatParsing.fuzzyBudget(2), "2-letter alias -> exact only");
+		eq(1, FakePlayerChatParsing.fuzzyBudget(6), "6-letter word -> one typo");
+		eq(2, FakePlayerChatParsing.fuzzyBudget(9), "long name -> two typos");
+
+		// nearestWithin returns the lone closest inside budget; a tie returns null so the caller asks, not guesses.
+		final List<String> cands = List.of("warcryer", "prophet", "bishop", "healer", "dancer");
+		eq("warcryer", FakePlayerChatParsing.nearestWithin("warcyer", cands, 1), "typo resolves to nearest");
+		eq(null, FakePlayerChatParsing.nearestWithin("zzzzzz", cands, 1), "nothing within budget -> null");
+		truth(FakePlayerChatParsing.nearestWithin("xealer", List.of("healer", "dealer"), 1) == null, "ambiguous tie -> null");
+
+		// minDistance is the closest of the whole set.
+		eq(1, FakePlayerChatParsing.minDistance("warcyer", cands), "minDistance finds the 1-off candidate");
+		eq(Integer.MAX_VALUE, FakePlayerChatParsing.minDistance("dd", java.util.List.of()), "empty candidates -> MAX_VALUE");
 	}
 
 	// ===== tiny assertion helpers =====


### PR DESCRIPTION
…nd split buff vs song/dance slots

- Sword Singers now use their full song rotation previously capped at 3 hardcoded songs; now keep every song they've learned running.
- Bladedancers now use their full dance rotation same 3-dance cap removed; full learned set now runs.
- Songs/dances can be requested by name e.g. "sing song of wind", "dance of fire" not just the whole rotation (new feature).
- Two music classes share the pool sensibly a Sword Singer + Bladedancer in one party no longer evict each other's songs/dances.
- Warcryer & Overlord phantoms now actually buff their "Chant" / "Pa'agrio" skills were missing from the buffer's whitelist, so they said "rebuffing" but cast nothing.
- Fixed the Warcryer buff-loop a Warcryer inherits Orc Shaman skills, so it knew two buffs for the same slot (e.g. Chant of Shielding + Blessings of Pa'agrio, both P.Def) and recast them endlessly; the buffer now tracks the effect slot instead of the skill, so each slot is buffed once and stays stable. (Same fix also covers the personal support buddy.)
- Recruit shouts now understand class shorthand. Aliases like se, wc, ee, ol, bp, sws, bd now recruit the exact class you mean (Shillien Elder, Warcryer, Elven Elder, etc.) instead of a generic default.
- Typos in class names are auto-corrected. Misspellings like warcyer or bishpo still recruit the right class.
- Unclear requests get a reply, not a wrong spawn. If a class word is too garbled to read, a nearby player whispers you to ask which class you meant and on a mixed request, the classes it could read are still recruited while it only asks about the unclear one.
- Buffers no longer spam a buff they can't apply. If you already have a stronger version of a buff (e.g. a P.Atk herb), the buffer skips it instead of endlessly re-casting; it will also upgrade a weaker buff you already have and refresh buffs just before they expire.
- Phantom melee now spawns in no-grade gear