### PR TITLE
Phantom party fixes: gear pool, camp pull openers, spoiler recruit

### DIFF
--- a/L2J_Mobius_CT_0_Interlude github/dist/game/data/PhantomPlaystyles.xml
+++ b/L2J_Mobius_CT_0_Interlude github/dist/game/data/PhantomPlaystyles.xml
@@ -16,8 +16,13 @@
 	<skill> attributes:
 	  id           - skill id (level resolved from what the member learned)
 	  name         - documentation only (the id is authoritative)
-	  use          - OPENER | ROTATION | AOE | DEBUFF | CONTROL | PANIC | LIMIT
+	  use          - OPENER | ROTATION | AOE | DEBUFF | CONTROL | PANIC | LIMIT | PULL
 	                 (PANIC/LIMIT target self; LIMIT additionally needs a ready healer)
+	                 PULL is special: it is the ranged opener the CAMP PULLER uses to tag a mob (so a nuker
+	                 shoots it instead of running in to body-pull) and is read ONLY by the pull hook, never by
+	                 the combat rotation. Use a cheap single-target nuke. Its `when` is ignored - the pull hook
+	                 supplies its own gating (in cast range, and above the role's MP reserve). TANKS pull with
+	                 Aggression, which is manager-owned and handled in code, so it is NOT listed here.
 	  when         - comma-separated AND conditions:
 	                 ALWAYS, TARGET_HP_BELOW (hpBelow), TARGET_HP_ABOVE (hpAbove),
 	                 SELF_HP_BELOW (selfHpBelow), MP_ABOVE (mpAbove), MOBS_NEAR (mobsAtLeast),
@@ -106,6 +111,7 @@
 	<!-- Human Mystic (10) -> wizard AND cleric roots. Only the offense is listed (heals are
 	     manager-owned): element bolts, the HP-drain nuke, and the two early curses on durable targets. -->
 	<playstyle name="Human Mystic (base)" classIds="10">
+		<skill id="1177" name="Wind Strike"     use="PULL"     when="ALWAYS" />
 		<skill id="1168" name="Curse: Poison"   use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1164" name="Curse: Weakness"  use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1147" name="Vampiric Touch"   use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -115,6 +121,7 @@
 
 	<!-- Elven Mystic (25) -> spellsinger/summoner + oracle/elder roots. Wind Shackle slows atk spd. -->
 	<playstyle name="Elven Mystic (base)" classIds="25">
+		<skill id="1177" name="Wind Strike"      use="PULL"     when="ALWAYS" />
 		<skill id="1206" name="Wind Shackle"     use="CONTROL"  when="DEBUFF_MISSING,DURABLE_TARGET" paceMs="8000" />
 		<skill id="1164" name="Curse: Weakness"  use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1184" name="Ice Bolt"         use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -123,6 +130,7 @@
 
 	<!-- Dark Mystic (38) -> spellhowler/summoner + shillien oracle/elder roots. -->
 	<playstyle name="Dark Mystic (base)" classIds="38">
+		<skill id="1177" name="Wind Strike"     use="PULL"     when="ALWAYS" />
 		<skill id="1206" name="Wind Shackle"    use="CONTROL"  when="DEBUFF_MISSING,DURABLE_TARGET" paceMs="8000" />
 		<skill id="1168" name="Curse: Poison"   use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1147" name="Vampiric Touch"  use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -179,6 +187,7 @@
 
 	<!-- Human Wizard (11) -> Sorcerer / Necromancer / Warlock. Sleep (1069) is manager-owned CC. -->
 	<playstyle name="Human Wizard (1st class)" classIds="11">
+		<skill id="1177" name="Wind Strike"  use="PULL"     when="ALWAYS" />
 		<skill id="1181" name="Flame Strike" use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1220" name="Blaze"        use="ROTATION" when="MP_ABOVE" mpAbove="35" />
 		<skill id="1274" name="Energy Bolt"  use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -188,6 +197,7 @@
 
 	<!-- Elven Wizard (26) -> Spellsinger / Elemental Summoner. -->
 	<playstyle name="Elven Wizard (1st class)" classIds="26">
+		<skill id="1177" name="Wind Strike"  use="PULL"     when="ALWAYS" />
 		<skill id="1181" name="Flame Strike" use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1175" name="Aqua Swirl"   use="ROTATION" when="MP_ABOVE" mpAbove="35" />
 		<skill id="1274" name="Energy Bolt"  use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -197,6 +207,7 @@
 
 	<!-- Dark Wizard (39) -> Spellhowler / Phantom Summoner. -->
 	<playstyle name="Dark Wizard (1st class)" classIds="39">
+		<skill id="1177" name="Wind Strike"   use="PULL"     when="ALWAYS" />
 		<skill id="1181" name="Flame Strike"  use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1178" name="Twister"       use="ROTATION" when="MP_ABOVE" mpAbove="35" />
 		<skill id="1266" name="Shadow Spark"  use="ROTATION" when="MP_ABOVE" mpAbove="30" />
@@ -368,6 +379,7 @@
 	<!-- Sorcerer line: fire. Element debuff first on anything durable, then pack AoEs (a real 3+ pack gets the AoE,
 	     not a single-target opener), then the single-target rotation. -->
 	<playstyle name="Archmage" classIds="12,94">
+		<skill id="1177" name="Wind Strike"       use="PULL"     when="ALWAYS" />
 		<skill id="1083" name="Surrender To Fire" use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" maxLevel="59" />
 		<skill id="1296" name="Rain of Fire"      use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1171" name="Blazing Circle"    use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" maxLevel="69" />
@@ -381,6 +393,7 @@
 	<!-- Necromancer line: Death Spike needs Cursed Bones in the inventory - Vampiric Claw is the
 	     reagent-free fallback so a boneless Soultaker still fights. -->
 	<playstyle name="Soultaker" classIds="13,95">
+		<skill id="1177" name="Wind Strike"       use="PULL"     when="ALWAYS" />
 		<skill id="1263" name="Curse Gloom"       use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1064" name="Silence"           use="CONTROL"  when="DEBUFF_MISSING,DURABLE_TARGET" paceMs="10000" />
 		<skill id="1170" name="Anchor"            use="CONTROL"  when="DURABLE_TARGET" paceMs="15000" />
@@ -393,6 +406,7 @@
 
 	<!-- Spellsinger line: water. Pack AoEs ahead of the single-target rotation. -->
 	<playstyle name="Mystic Muse" classIds="27,103">
+		<skill id="1177" name="Wind Strike"        use="PULL"     when="ALWAYS" />
 		<skill id="1071" name="Surrender To Water" use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1174" name="Frost Wall"         use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1181" name="Flame Strike"       use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" maxLevel="45" />
@@ -404,6 +418,7 @@
 
 	<!-- Spellhowler line: wind. Pack AoEs ahead of the single-target rotation. -->
 	<playstyle name="Storm Screamer" classIds="40,110">
+		<skill id="1177" name="Wind Strike"       use="PULL"     when="ALWAYS" />
 		<skill id="1074" name="Surrender To Wind" use="DEBUFF"   when="DEBUFF_MISSING,DURABLE_TARGET" />
 		<skill id="1176" name="Tempest"           use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" />
 		<skill id="1181" name="Flame Strike"      use="AOE"      when="MOBS_NEAR" mobsAtLeast="3" maxLevel="45" />

--- a/L2J_Mobius_CT_0_Interlude github/dist/game/data/xsd/PhantomPlaystyles.xsd
+++ b/L2J_Mobius_CT_0_Interlude github/dist/game/data/xsd/PhantomPlaystyles.xsd
@@ -20,6 +20,7 @@
 												<xs:enumeration value="CONTROL" />
 												<xs:enumeration value="PANIC" />
 												<xs:enumeration value="LIMIT" />
+												<xs:enumeration value="PULL" />
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:attribute>

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/launcher.ps1
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/launcher.ps1
@@ -80,11 +80,14 @@ function Register-LaunchedProcess($role, $process, $marker) {
 function Assert-NoManagedProcesses {
     if (-not (Test-Path $ProcessRegistryPath)) { return }
     try {
-        $records = @(Get-Content -Raw $ProcessRegistryPath | ConvertFrom-Json)
+        # Assign first, then wrap with @() when iterating. In Windows PowerShell 5.1
+        # ConvertFrom-Json returns a multi-record array as a single non-enumerated
+        # object, so @(pipeline) would nest it and $record would bind to the inner array.
+        $records = Get-Content -Raw $ProcessRegistryPath | ConvertFrom-Json
     } catch {
         Fail "Process registry is unreadable: $ProcessRegistryPath. Inspect or remove it before starting."
     }
-    foreach ($record in $records) {
+    foreach ($record in @($records)) {
         $existing = Get-Process -Id ([int]$record.Id) -ErrorAction SilentlyContinue
         if ($existing) {
             try { $ticks = "$($existing.StartTime.ToUniversalTime().Ticks)" } catch { $ticks = '' }

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/stop.ps1
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/stop.ps1
@@ -82,13 +82,18 @@ function Stop-RecordedProcesses {
     }
 
     try {
-        $records = @(Get-Content -Raw $ProcessRegistryPath | ConvertFrom-Json)
+        # Assign first, then wrap with @(). In Windows PowerShell 5.1 a multi-record
+        # array is returned by ConvertFrom-Json as a single non-enumerated object, so
+        # @(pipeline) would nest it into a one-element array and $record would bind to
+        # the inner array (making $record.Id an Object[]). Wrapping the variable flattens
+        # correctly for one record, many records, or none.
+        $records = Get-Content -Raw $ProcessRegistryPath | ConvertFrom-Json
     } catch {
         Write-Warn "Process registry is unreadable; refusing to guess which processes belong to the server."
         return
     }
 
-    foreach ($record in $records) {
+    foreach ($record in @($records)) {
         $processId = [int]$record.Id
         $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
         if (-not $process) {

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/data/xml/PhantomPlaystyleData.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/data/xml/PhantomPlaystyleData.java
@@ -60,7 +60,9 @@ public class PhantomPlaystyleData implements IXmlReader
 		DEBUFF, // target weakening worth the cast only on durable targets
 		CONTROL, // stun/slow/root style interruption
 		PANIC, // self-defense at low HP while under attack (targets self)
-		LIMIT; // low-HP limit buffs (Frenzy/Zealot family): healer-gated, skill data enforces its own HP gate (targets self)
+		LIMIT, // low-HP limit buffs (Frenzy/Zealot family): healer-gated, skill data enforces its own HP gate (targets self)
+		PULL; // ranged tag the camp puller opens a pull with (a cheap single-target nuke); read ONLY by the pull
+		// hook, never by the combat rotation - so a nuker that would otherwise body-pull instead shoots the mob.
 
 		public boolean self()
 		{

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerAppearanceFactory.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerAppearanceFactory.java
@@ -578,9 +578,9 @@ public class FakePlayerAppearanceFactory
 		}
 		for (ItemTemplate item : ItemData.getInstance().getAllItems())
 		{
-			if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || !FakePlayerGearFilter.isPlayerGear(item))
+			if ((item == null) || !item.isEquipable() || !item.isTradeable() || (item.getReferencePrice() <= 0) || item.isForNpc() || !FakePlayerGearFilter.isPlayerGear(item))
 			{
-				continue; // skip pet/summon/monster gear that renders as a sack / invisible slot
+				continue; // skip pet/summon/monster gear (for_npc) that renders as a sack / invisible slot
 			}
 			final CrystalType grade = item.getCrystalType();
 			final int id = item.getId();

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerChatManager.java
@@ -702,6 +702,12 @@ public class FakePlayerChatManager implements IXmlReader
 		putClassAlias("sws", "swordsinger");
 		putClassAlias("bd", "bladedancer");
 		putClassAlias("spectral", "spectral dancer");
+		// "spoiler" is what players ask for when they want a dwarf: it names the Bounty Hunter (Scavenger) line, and
+		// the level walk resolves it to Scavenger / Bounty Hunter / Fortune Seeker for the party's level. This is the
+		// only way a dwarf now joins as a damage dealer - the generic "dd" pool no longer rolls them (see DPS_RACES).
+		putClassAlias("spoiler", "bounty hunter");
+		putClassAlias("spoil", "bounty hunter");
+		putClassAlias("bh", "bounty hunter");
 		// Build the exact-match pattern from every key (names + aliases), longest first so a multi-word class wins
 		// over a shorter substring. Trailing "s?" so a plural request ("2 bishops", "3 hawkeyes") still matches.
 		final List<String> keys = new ArrayList<>(CLASS_BY_NAME.keySet());

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerGearFilter.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/FakePlayerGearFilter.java
@@ -38,8 +38,12 @@ import org.l2jmobius.gameserver.model.item.ItemTemplate;
  * <li>armor pieces with no model for some race (e.g. "Tunic of Mana", which is invisible on an Orc mystic) were
  * deliberately left out of the GM gear lists, so drawing only from here <b>needs no race-specific skip</b>.</li>
  * </ul>
- * The only residue is a handful of NPC weapons named "Monster Only(...)" that sit in the weapon lists; those are
- * dropped by name when the allow-list is built.
+ * NPC-only weapons are dropped by the {@code isForNpc()} data flag when the allow-list is built (the "Monster
+ * Weapons" section: Tomb Guard, For NPC (Dusk), "Monster Only ..."), which is robust where the old "Monster Only"
+ * name match missed variants. Items with an UNMEETABLE equip gate (Clan Oath's academy pledgeClass, hero/noble
+ * gear) are NOT filtered here - most normal armor carries a benign all-races {@code <conditions>} block, so a
+ * blanket condition filter would strip real gear - they are caught per-phantom at equip time in
+ * {@code PhantomManager.equipArmorSet} via {@link ItemTemplate#checkCondition}.
  * <p>
  * The allow-list is resolved lazily from {@link BuyListData} (already loaded at start-up) the first time gear is
  * built, so it stays in sync automatically if a buy-list is edited. If a listed buy-list id is missing it is
@@ -119,7 +123,14 @@ public class FakePlayerGearFilter
 				for (Product product : buyList.getProducts())
 				{
 					final ItemTemplate item = product.getItem();
-					if ((item != null) && !item.getName().contains("Monster Only")) // drop NPC weapons that leaked into the gear lists
+					// Drop NPC-only "Monster Weapons" (Tomb Guard, For NPC (Dusk), "Monster Only ...") by the for_npc
+					// data flag - robust where the old "Monster Only" NAME match missed the ones not named that way.
+					// Do NOT filter by isConditionAttached() here: most normal armor carries a benign <conditions>
+					// block (an all-races <player races=.../> list), so excluding any conditioned item stripped whole
+					// grades of real armor and shields. Items with an UNMEETABLE equip gate (Clan Oath's academy
+					// pledgeClass, hero/noble/olympiad) are caught per-phantom at equip time in
+					// PhantomManager.equipArmorSet via ItemTemplate.checkCondition instead.
+					if ((item != null) && !item.isForNpc())
 					{
 						built.add(item.getId());
 					}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomManager.java
@@ -482,12 +482,14 @@ public class PhantomManager implements IXmlReader
 			return DPS_ROLES[Rnd.get(DPS_ROLES.length)];
 		}
 
+		// A generic "dd"/"dps" rolls only PHYSICAL damage dealers. NUKER is deliberately excluded: a caster brings its
+		// own positioning/MP needs and is not what most players expect from a plain "dd", so it comes only from an
+		// explicit "nuker"/"mage" request (PartyRole.fromToken), never from the generic roll.
 		private static final PartyRole[] DPS_ROLES =
 		{
 			WARRIOR,
 			ARCHER,
 			DAGGER,
-			NUKER,
 			MONK
 		};
 	}
@@ -509,14 +511,18 @@ public class PhantomManager implements IXmlReader
 		return valid.isEmpty() ? null : valid.get(Rnd.get(valid.size()));
 	}
 
-	/** The playable races a generic damage-dealer can be rolled from, so a bulk "N dd" call spreads across races. */
+	/**
+	 * The playable races a generic damage-dealer can be rolled from, so a bulk "N dd" call spreads across races.
+	 * Dwarves are deliberately EXCLUDED: their only damage archetype is a blunt/heavy melee that most players do not
+	 * want filling a generic DD slot - they are wanted as a spoiler, not a nuker/archer stand-in. A dwarf is still
+	 * recruited when asked for explicitly ("dwarf dd", or the "spoiler" token -> the Bounty Hunter line).
+	 */
 	private static final Race[] DPS_RACES =
 	{
 		Race.HUMAN,
 		Race.ELF,
 		Race.DARK_ELF,
-		Race.ORC,
-		Race.DWARF
+		Race.ORC
 	};
 
 	/**
@@ -2347,9 +2353,13 @@ public class PhantomManager implements IXmlReader
 	private void equipArmorSet(Player phantom, ArmorType family, CrystalType grade, int enchant, boolean wantShield)
 	{
 		final FakePlayerArmorSets.Outfit outfit = FakePlayerArmorSets.random(family, grade);
-		if (outfit == null)
+		final ItemTemplate chest = (outfit == null) ? null : ItemData.getInstance().getTemplate(outfit.chest);
+		// No set for this family/grade, OR the rolled set's chest can't actually be worn by this phantom (an
+		// academy-gated set like Clan Oath - pledgeClass condition no phantom meets - would otherwise be added to the
+		// bag and left unequipped). Sets are uniform, so the chest is a reliable proxy for the whole set. Fall back to
+		// the best per-slot pieces (body family-correct, extremities agnostic), each guarded the same way.
+		if (!canEquip(phantom, chest))
 		{
-			// No set for this family/grade - fall back to best per-slot (body family-correct, extremities agnostic).
 			for (BodyPart slot : GEAR_SLOTS)
 			{
 				if (slot == BodyPart.R_HAND)
@@ -2357,14 +2367,18 @@ public class PhantomManager implements IXmlReader
 					continue;
 				}
 				final ItemTemplate piece = bestArmor(slot, grade, family, null);
-				if (piece != null)
+				if (canEquip(phantom, piece))
 				{
 					equip(phantom, piece, enchant);
 				}
 			}
 			if (wantShield)
 			{
-				equipPiece(phantom, bestEquip(grade, item -> (item instanceof Armor) && (((Armor) item).getItemType() == ArmorType.SHIELD)), enchant);
+				final ItemTemplate shield = bestEquip(grade, item -> (item instanceof Armor) && (((Armor) item).getItemType() == ArmorType.SHIELD));
+				if (canEquip(phantom, shield))
+				{
+					equip(phantom, shield, enchant);
+				}
 			}
 			return;
 		}
@@ -2718,6 +2732,17 @@ public class PhantomManager implements IXmlReader
 			grade = (grade.ordinal() > 0) ? CrystalType.values()[grade.ordinal() - 1] : null;
 		}
 		return null;
+	}
+
+	/**
+	 * @return {@code true} if {@code phantom} can actually equip {@code t} right now - it is equipable AND all of the
+	 *         item's own equip conditions pass. Normal armor carries only a benign all-races {@code <player>} condition
+	 *         (always passes); this rejects the unmeetable social gates a phantom never satisfies (Clan Oath's academy
+	 *         {@code pledgeClass}, hero/noble/olympiad items), which would otherwise be added to the bag unequipped.
+	 */
+	private static boolean canEquip(Player phantom, ItemTemplate t)
+	{
+		return (t != null) && t.isEquipable() && t.checkCondition(phantom, phantom, false);
 	}
 
 	/** Adds a single template to the phantom's inventory and equips it. */

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -511,6 +511,7 @@ public class PhantomPartyManager
 		int pullerId; // objectId of the designated puller (0 = passive camp: hold and fight only what wanders in)
 		Monster pulling; // the mob currently being fetched/dragged home (null between runs)
 		boolean hauling; // true while running the load home, so the MOVE_TO isn't re-issued every tick (path stutter)
+		boolean pullTagged; // the current run's ranged opener (tank taunt / nuker tag) has fired - at most once per pull
 		long pullStartedAt; // when the current fetch began, for the stuck/timeout guard
 		long nextPullAt; // don't launch the next fetch until this time (the rest beat between pulls)
 
@@ -2303,6 +2304,7 @@ public class PhantomPartyManager
 		{
 			camp.pulling = null;
 			camp.hauling = false;
+			camp.pullTagged = false;
 			camp.nextPullAt = now + PULL_INTERVAL;
 		}
 
@@ -2384,11 +2386,12 @@ public class PhantomPartyManager
 		}
 		camp.pulling = prey;
 		camp.hauling = false;
+		camp.pullTagged = false;
 		camp.pullStartedAt = now;
 		standIfSitting(npc);
 		npc.setTarget(prey);
 		npc.setRunning();
-		npc.getAI().setIntention(Intention.ATTACK, prey); // run out and tag it
+		npc.getAI().setIntention(Intention.ATTACK, prey); // run out and tag it (a skill opener lands once in range, see haulBack)
 		bark(state, "You're the camp's puller and you're running out to grab " + prey.getName() + " to bring back to the party. Say it in one very short line.", "pulling, get ready");
 	}
 
@@ -2398,6 +2401,13 @@ public class PhantomPartyManager
 		final Player npc = state.npc;
 		final Monster prey = camp.pulling;
 		if (prey == null)
+		{
+			return;
+		}
+		// A pull-tag skill (tank taunt / nuker tag) is still going out - let it finish before any branch below
+		// re-issues a move or attack that would interrupt it. Physical body-pulling never trips this (auto-attack
+		// is not a cast), so it only holds for the ranged opener.
+		if (npc.isCastingNow())
 		{
 			return;
 		}
@@ -2417,7 +2427,10 @@ public class PhantomPartyManager
 		}
 		// Have a load on us (or nothing else close): run back to camp, dragging whatever aggroed. Issue the MOVE_TO
 		// once (not every tick - that re-paths and stutters the run) and only re-nudge it if the run stalls.
-		if ((mobsHating(npc) > 0) || (prey.getMostHated() == npc))
+		// camp.pullTagged: once a ranged opener has been thrown, head home IMMEDIATELY even if the tag's hate has not
+		// registered yet this tick - otherwise the body-pull branch below would run a caster INTO melee in that gap
+		// (the "stopped at range, then got dragged onto the mob mid/after cast and died" bug).
+		if ((mobsHating(npc) > 0) || (prey.getMostHated() == npc) || camp.pullTagged)
 		{
 			if (!camp.hauling || !npc.isMoving())
 			{
@@ -2427,12 +2440,82 @@ public class PhantomPartyManager
 			}
 			return;
 		}
-		// Nothing has latched on yet: keep tagging the prey until it does.
+		// Nothing has latched on yet. A ranged puller opens with a skill once it has closed to cast range - a TANK
+		// taunts, a nuker fires its use="PULL" tag - so it does not run into melee to body-pull. A puller still out of
+		// range, low on MP, or with no pull skill falls through and body-pulls exactly as before.
+		if (tryPullTag(state, camp, prey))
+		{
+			return;
+		}
 		camp.hauling = false;
 		standIfSitting(npc);
 		npc.setTarget(prey);
 		npc.setRunning();
 		npc.getAI().setIntention(Intention.ATTACK, prey);
+	}
+
+	/**
+	 * The puller's ranged pull opener, fired at most once per pull run and only once the puller is in cast range: a
+	 * TANK grabs the mob with the manager-owned taunt (Aggression - single-target, long range, hate without needing
+	 * to land damage); any other class fires the cheap single-target nuke its playstyle marks {@code use="PULL"}. This
+	 * is what makes a nuker shoot the mob instead of running into melee, and a tank pull with hate instead of its face.
+	 * Returns {@code false} - so the caller body-pulls as before - when the puller has no pull skill, is still closing,
+	 * is low on MP, or the opener is on cooldown / refused by the core.
+	 * @return {@code true} if a skill cast launched this tick (caller skips the body-pull attack re-issue)
+	 */
+	private boolean tryPullTag(Member state, Camp camp, Monster prey)
+	{
+		if (camp.pullTagged) // already opened this run - the body-pull carries it home from here
+		{
+			return false;
+		}
+		final Player npc = state.npc;
+		if (npc.isCastingNow()) // a tag launched on an earlier tick is still going out - let it finish
+		{
+			return true;
+		}
+		// TANK: pull with Aggression, which is manager-owned and so never listed in the playstyle. Resolve it lazily
+		// (the tank may not have taunted yet this session) exactly as maintainThreat does.
+		if (state.role == PartyRole.TANK)
+		{
+			resolveTaunts(state);
+			if (castable(npc, state.aggression) && (npc.calculateDistance2D(prey) <= state.aggression.getCastRange()))
+			{
+				standIfSitting(npc);
+				// Drop the run-out ATTACK pursuit BEFORE casting: it seeks melee range, and left active it drags the
+				// puller onto the mob during the cast. Stand where we are, tag, then haulBack runs the mob home.
+				npc.getAI().setIntention(Intention.IDLE);
+				npc.setTarget(prey);
+				npc.doCast(state.aggression);
+				if (npc.isCastingNow() || npc.isCastingSimultaneouslyNow())
+				{
+					camp.pullTagged = true;
+					return true;
+				}
+			}
+			return false; // out of range / on cooldown / core refused - keep closing and body-pull, retry next tick
+		}
+		// Everyone else: the class's use="PULL" tag (a cheap single-target nuke), if it has one and is in range with
+		// mana to spare. Melee and archers list none, so they body-pull as before (an archer's bow auto-shot already
+		// tags from range).
+		final PhantomPlaystyleEngine.CastAction action = PhantomPlaystyleEngine.pickPullTag(npc, prey, state.play, mpReserve(state.role), state.role.name());
+		if (action == null)
+		{
+			return false;
+		}
+		standIfSitting(npc);
+		// Drop the run-out ATTACK pursuit BEFORE casting (see the tank branch): for a caster it seeks melee range, so
+		// left active it drags her onto the mob mid-cast where she takes hits. Stand and tag from range; haulBack then
+		// runs the tagged mob back to camp.
+		npc.getAI().setIntention(Intention.IDLE);
+		npc.setTarget(action.target);
+		npc.doCast(action.skill);
+		if (npc.isCastingNow() || npc.isCastingSimultaneouslyNow())
+		{
+			camp.pullTagged = true;
+			return true;
+		}
+		return false; // core refused the cast (range/interrupt/target gone) - body-pull this tick, retry the tag next
 	}
 
 	/** Nearest live, non-raid mob within pull range of the anchor that isn't already on the puller or the party. */

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPlaystyleEngine.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPlaystyleEngine.java
@@ -147,7 +147,10 @@ public class PhantomPlaystyleEngine
 		int count = 0;
 		for (PlayEntry entry : playstyle.entries)
 		{
-			if (entry.appliesAt(level) && (npc.getKnownSkill(entry.skillId) != null))
+			// PULL entries are pull-only openers the combat rotation never fires, so they must not, on their own,
+			// count as "this playstyle can field something" - otherwise a class listing only a PULL tag would be
+			// parked out of AutoUse and then stand silent in a fight (pick() skips PULL).
+			if ((entry.use != Use.PULL) && entry.appliesAt(level) && (npc.getKnownSkill(entry.skillId) != null))
 			{
 				count++;
 			}
@@ -197,6 +200,12 @@ public class PhantomPlaystyleEngine
 
 		for (PlayEntry entry : entries)
 		{
+			// PULL is a pull-only opener consumed by the party manager's pull hook, never part of the combat
+			// rotation - so a manager-owned taunt or a cheap tag nuke listed for pulling is not spammed in a fight.
+			if (entry.use == Use.PULL)
+			{
+				continue;
+			}
 			// Outside its authored level window (a level 80 archer has outgrown Power Shot).
 			if (!entry.appliesAt(level))
 			{
@@ -310,6 +319,64 @@ public class PhantomPlaystyleEngine
 				return null;
 			}
 			return new CastAction(skill, npc, false, 0, entry.skillId); // self-cast; not a once-per-target ledger entry
+		}
+		return null;
+	}
+
+	/**
+	 * The ranged tag a camp puller should open a pull with, so a nuker shoots the mob instead of running into melee to
+	 * body-pull it. Returns the first {@code use="PULL"} entry that is castable on {@code prey} RIGHT NOW - learned,
+	 * inside its level window, off cooldown, affordable, and already in cast range - else {@code null} (the puller then
+	 * keeps closing and body-pulls as before). PULL entries are read only here; the combat rotation never fires them.
+	 * <p>
+	 * Range is deliberately part of the gate: the puller starts at camp, far from the prey, so this returns {@code null}
+	 * on the outbound run and only fires once the puller has closed to the tag skill's range. Below {@code mpReservePercent}
+	 * the puller skips the tag and body-pulls, so a low-MP mage does not spend its fight mana just to pull.
+	 * @param npc the puller
+	 * @param prey the mob being fetched
+	 * @param state the member's playstyle runtime state
+	 * @param mpReservePercent below this own-MP percent, tag with a skill is skipped in favour of a body-pull
+	 * @param roleName the member's party role name, used to resolve role-split lineages
+	 */
+	public static CastAction pickPullTag(Player npc, Monster prey, PlayState state, int mpReservePercent, String roleName)
+	{
+		final int classId = npc.getPlayerClass().getId();
+		state.refreshIfReloaded();
+		if (!state.lookedUp)
+		{
+			state.lookedUp = true;
+			state.playstyle = PhantomPlaystyleData.getInstance().getPlaystyle(classId, roleName);
+		}
+		if (state.playstyle == null)
+		{
+			return null;
+		}
+		final int level = npc.getLevel();
+		final int mpPercent = npc.getCurrentMpPercent();
+		for (PlayEntry entry : state.playstyle.entries)
+		{
+			if ((entry.use != Use.PULL) || !entry.appliesAt(level))
+			{
+				continue;
+			}
+			if (mpPercent < mpReservePercent)
+			{
+				return null; // too low on mana to spend on a pull tag - body-pull and keep the mana for the fight
+			}
+			final Skill skill = npc.getKnownSkill(entry.skillId);
+			if ((skill == null) || npc.isSkillDisabled(skill) || (npc.getCurrentMp() < skill.getMpConsume()) || !PhantomBuffs.canAffordReagent(npc, skill))
+			{
+				continue;
+			}
+			if (!inReach(npc, prey, skill))
+			{
+				return null; // still closing the distance - the caller body-pulls this tick and retries when in range
+			}
+			if (!skill.checkCondition(npc, prey, false))
+			{
+				continue;
+			}
+			return new CastAction(skill, prey, false, 0, entry.skillId);
 		}
 		return null;
 	}

--- a/L2J_Mobius_CT_0_Interlude github/tools/l2admin/index.html
+++ b/L2J_Mobius_CT_0_Interlude github/tools/l2admin/index.html
@@ -246,6 +246,7 @@
   .u-CONTROL {color:#7fc4b0;border-color:#7fc4b055;background:#7fc4b018}
   .u-PANIC   {color:#d88a8a;border-color:#d88a8a55;background:#d88a8a18}
   .u-LIMIT   {color:#c98ad8;border-color:#c98ad855;background:#c98ad818}
+  .u-PULL    {color:#8fd8a8;border-color:#8fd8a855;background:#8fd8a818}
 
   .ps-body{min-width:0}
   .ps-name{font-size:14px;font-weight:600;color:var(--ink);display:flex;align-items:center;gap:8px;flex-wrap:wrap}
@@ -930,7 +931,7 @@ function discardAll(){
 
 const PS_FILE = "PhantomPlaystyles.xml";
 const ICON_SUBDIR = "skill icons"; // icons ship next to the datapack at game/data/skill icons
-const PS_USES = ["OPENER","ROTATION","AOE","DEBUFF","CONTROL","PANIC","LIMIT"];
+const PS_USES = ["OPENER","ROTATION","AOE","DEBUFF","CONTROL","PANIC","LIMIT","PULL"];
 const PS_ROLES = ["TANK","WARRIOR","ARCHER","DAGGER","MONK","SINGER","DANCER","NUKER"];
 
 // Condition -> the numeric attribute it pairs with (null = the condition takes no parameter).


### PR DESCRIPTION
- Exclude NPC-only weapons from the phantom and fake-player gear pool by the for_npc data flag, so recruits no longer equip monster weapons.
- Skip academy/hero/noble armor a phantom cannot wear at equip time and fall back to per-slot pieces, so a recruit is never left with unequipped armor.
- Add ranged pull openers for camp-and-pull: a nuker tags with a cheap spell and a tank pulls with Aggression instead of body-pulling into melee, and the puller no longer walks into melee mid-cast.
- Generic "dd" now rolls only physical damage dealers; add a "spoiler" recruit token that resolves to the level-appropriate Bounty Hunter line, and stop dwarves rolling from the generic damage-dealer pool.
- Fix the launcher stop script failing to parse the process registry under Windows PowerShell 5.1 when more than one process is recorded.