### PR TITLE
fix: harden Bounty Hunter loot/sweep and stop patching locked launche…

### DIFF
--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
@@ -49,5 +49,7 @@ Start-Server.bat
 Stop-Server.bat
 launcher/launcher.ps1
 launcher/stop.ps1
-launcher/assets/background.png
-launcher/assets/launcher.ico
+# launcher/assets/* is intentionally NOT patched: the running LivingWorld.exe holds
+# these open (e.g. launcher.ico as its window icon), so overwriting them mid-update
+# fails with a file-in-use error and aborts the whole patch. Ship changed launcher
+# assets in the full pack instead.

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -1133,7 +1133,7 @@ public class PhantomPartyManager
 		{
 			_pendingTrades = new CopyOnWriteArrayList<>();
 			_members.values().stream()
-					.filter(member -> member.lootingSessionItems != null && !member.lootingSessionItems.isEmpty())
+					.filter(member -> member.owner == owner && member.lootingSessionItems != null && !member.lootingSessionItems.isEmpty())
 					.collect(Collectors.toCollection(() -> _pendingTrades));
 			if (_pendingTrades.isEmpty()) {
 				return false;
@@ -1393,7 +1393,7 @@ public class PhantomPartyManager
 		if (containsAny(text, "return loot", "hand over loot", "hand over loot"))
 		{
 			Map<Integer, Integer> spoils = state.lootingSessionItems;
-			if (spoils.isEmpty()) {
+			if (spoils == null || spoils.isEmpty()) {
 				deliver(state, "nothing to hand over yet, how about a few more mobs then?");
 				return true;
 			}
@@ -2693,6 +2693,12 @@ public class PhantomPartyManager
 		if (!state.scavengerKitLookedUp) {
 			state.sweeper = npc.getKnownSkill(SWEEPER_SKILL_ID);
 			state.scavengerKitLookedUp = true;
+		}
+
+		// Without the Sweeper skill there is nothing to cast on a spoiled corpse; never enter
+		// sweeping mode, or runSweepOnSelectedCorpses would dereference a null sweeper.
+		if (state.sweeper == null) {
+			return false;
 		}
 
 		if (!state.fieldSweepingInProcess) {


### PR DESCRIPTION
…r assets

Follow-up to the Bounty Hunter phantom feature (PR #18).

PhantomPartyManager:
- Scope 'party return loot' to the caller's own party (member.owner == owner); it previously collected every looting phantom across all parties.
- Guard the 'return loot' handler against a null looting session so a member that never looted (or was cleared after a hand-over) replies instead of throwing NullPointerException.
- Skip field sweeping when the member has no Sweeper skill, so runSweepOnSelectedCorpses never dereferences a null sweeper.

patch-manifest.txt:
- Stop shipping launcher/assets/* (launcher.ico, background.png) in the incremental patch. The running LivingWorld.exe holds these open, so the overlay copy fails with a file-in-use error and aborts the whole update. Changed launcher assets ship in the full pack instead.

Type-checked clean on JDK 21 (--enable-preview --release 21); JDK 25 + Ant release build and in-game validation still pending.