### PR TITLE
draft: development configs for development purposes

### DIFF
--- a/L2J_Mobius_CT_0_Interlude github/.gitignore
+++ b/L2J_Mobius_CT_0_Interlude github/.gitignore
@@ -10,6 +10,5 @@
 # regenerate with the tool; the server loads PhantomPopulations.xml, not this side file).
 /dist/game/data/PhantomPopulations.generated.xml
 
-# Added this temporarily, should be swapped with dev config when it's ready
-/dist/game/config
-/dist/login/config
+/dist/game/devconfig
+/dist/login/devconfig

--- a/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
+++ b/L2J_Mobius_CT_0_Interlude github/dist/launcher/patch-manifest.txt
@@ -49,5 +49,7 @@ Start-Server.bat
 Stop-Server.bat
 launcher/launcher.ps1
 launcher/stop.ps1
-launcher/assets/background.png
-launcher/assets/launcher.ico
+# launcher/assets/* is intentionally NOT patched: the running LivingWorld.exe holds
+# these open (e.g. launcher.ico as its window icon), so overwriting them mid-update
+# fails with a file-in-use error and aborts the whole patch. Ship changed launcher
+# assets in the full pack instead.

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/DatabaseConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/DatabaseConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class DatabaseConfig
 {
-	// File
-	private static final String DATABASE_CONFIG_FILE = "./config/Database.ini";
-	
 	// Constants
 	public static String DATABASE_DRIVER;
 	public static String DATABASE_URL;
@@ -43,9 +40,10 @@ public class DatabaseConfig
 	public static String BACKUP_PATH;
 	public static int BACKUP_DAYS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(DATABASE_CONFIG_FILE);
+		String databaseConfigFile = String.format("./%s/Database.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(databaseConfigFile);
 		DATABASE_DRIVER = config.getString("Driver", "com.mysql.cj.jdbc.Driver");
 		DATABASE_URL = config.getString("URL", "jdbc:mysql://localhost/l2jmobius");
 		DATABASE_LOGIN = config.getString("Login", "root");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/InterfaceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/InterfaceConfig.java
@@ -30,16 +30,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class InterfaceConfig
 {
-	// File
-	private static final String INTERFACE_CONFIG_FILE = "./config/Interface.ini";
-	
 	// Constants
 	public static boolean ENABLE_GUI;
 	public static boolean DARK_THEME;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(INTERFACE_CONFIG_FILE);
+		String interfaceConfigFile = String.format("./%s/Interface.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(interfaceConfigFile);
 		ENABLE_GUI = config.getBoolean("EnableGUI", true) && !GraphicsEnvironment.isHeadless();
 		if (ENABLE_GUI)
 		{

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/ThreadConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/config/ThreadConfig.java
@@ -28,18 +28,16 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class ThreadConfig
 {
-	// File
-	private static final String THREADS_CONFIG_FILE = "./config/Threads.ini";
-	
 	// Constants
 	public static int SCHEDULED_THREAD_POOL_SIZE;
 	public static int HIGH_PRIORITY_SCHEDULED_THREAD_POOL_SIZE;
 	public static int INSTANT_THREAD_POOL_SIZE;
 	public static boolean THREADS_FOR_LOADING;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(THREADS_CONFIG_FILE);
+		String threadsConfigFile = String.format("./%s/Threads.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(threadsConfigFile);
 		
 		SCHEDULED_THREAD_POOL_SIZE = config.getInt("ScheduledThreadPoolSize", -1);
 		if (SCHEDULED_THREAD_POOL_SIZE == -1)

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/database/DatabaseFactory.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/database/DatabaseFactory.java
@@ -53,8 +53,9 @@ public class DatabaseFactory
 	/**
 	 * Initializes the HikariCP connection pool with optimized settings.<br>
 	 * Ensures that the pool is initialized only once.
+	 * @param baseConfigPath base directory holding the configuration files
 	 */
-	public static synchronized void init()
+	public static synchronized void init(String baseConfigPath)
 	{
 		if ((DATABASE_POOL != null) && !DATABASE_POOL.isClosed())
 		{
@@ -63,7 +64,7 @@ public class DatabaseFactory
 		}
 		
 		// Load configurations.
-		DatabaseConfig.load();
+		DatabaseConfig.load(baseConfigPath);
 		
 		try
 		{

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/threads/ThreadPool.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/commons/threads/ThreadPool.java
@@ -61,13 +61,14 @@ public class ThreadPool
 	
 	/**
 	 * Initializes thread pool executors and starts maintenance tasks.
+	 * @param baseConfigPath base directory holding the configuration files
 	 */
-	public static void init()
+	public static void init(String baseConfigPath)
 	{
 		LOGGER.info("ThreadPool: Initializing.");
 		
 		// Load configurations.
-		ThreadConfig.load();
+		ThreadConfig.load(baseConfigPath);
 		
 		// Configure High Priority ScheduledThreadPoolExecutor.
 		if (ThreadConfig.HIGH_PRIORITY_SCHEDULED_THREAD_POOL_SIZE > 0)

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
@@ -166,6 +166,8 @@ import org.l2jmobius.gameserver.taskmanagers.ItemLifeTimeTaskManager;
 import org.l2jmobius.gameserver.taskmanagers.ItemsAutoDestroyTaskManager;
 import org.l2jmobius.gameserver.ui.Gui;
 import org.l2jmobius.gameserver.util.Broadcast;
+import org.l2jmobius.gameserver.util.argsparse.GameServerLaunchArgs;
+import org.l2jmobius.gameserver.util.argsparse.GameServerLaunchArgumentsParser;
 
 public class GameServer
 {
@@ -175,10 +177,12 @@ public class GameServer
 	private long _sectionStartTime = START_TIME;
 	private String _previousSectionName = null;
 	
-	public GameServer() throws Exception
+	public GameServer(String[] args) throws Exception
 	{
 		System.out.println("=== Living Worlds Server ===");
-		
+
+		GameServerLaunchArgs gameServerLaunchArgs = GameServerLaunchArgumentsParser.parse(args);
+
 		// GUI
 		InterfaceConfig.load();
 		if (InterfaceConfig.ENABLE_GUI)
@@ -196,9 +200,9 @@ public class GameServer
 		{
 			LogManager.getLogManager().readConfiguration(is);
 		}
-		
+
 		// Initialize config
-		ConfigLoader.init();
+		ConfigLoader.init(gameServerLaunchArgs.baseConfigPath());
 		
 		LOGGER.info("=== Living Worlds Server ===");
 		
@@ -503,6 +507,6 @@ public class GameServer
 	
 	public static void main(String[] args) throws Exception
 	{
-		new GameServer();
+		new GameServer(args);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
@@ -184,7 +184,7 @@ public class GameServer
 		GameServerLaunchArgs gameServerLaunchArgs = GameServerLaunchArgumentsParser.parse();
 
 		// GUI
-		InterfaceConfig.load();
+		InterfaceConfig.load(gameServerLaunchArgs.baseConfigPath());
 		if (InterfaceConfig.ENABLE_GUI)
 		{
 			System.out.println("GameServer: Running in GUI mode.");
@@ -207,10 +207,10 @@ public class GameServer
 		LOGGER.info("=== Living Worlds Server ===");
 		
 		printSection("Database");
-		DatabaseFactory.init();
+		DatabaseFactory.init(gameServerLaunchArgs.baseConfigPath());
 		
 		printSection("ThreadPool");
-		ThreadPool.init();
+		ThreadPool.init(gameServerLaunchArgs.baseConfigPath());
 		
 		// Start game time task manager early
 		GameTimeTaskManager.getInstance();

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/GameServer.java
@@ -177,18 +177,18 @@ public class GameServer
 	private long _sectionStartTime = START_TIME;
 	private String _previousSectionName = null;
 	
-	public GameServer(String[] args) throws Exception
+	public GameServer() throws Exception
 	{
 		System.out.println("=== Living Worlds Server ===");
 
-		GameServerLaunchArgs gameServerLaunchArgs = GameServerLaunchArgumentsParser.parse(args);
+		GameServerLaunchArgs gameServerLaunchArgs = GameServerLaunchArgumentsParser.parse();
 
 		// GUI
 		InterfaceConfig.load();
 		if (InterfaceConfig.ENABLE_GUI)
 		{
 			System.out.println("GameServer: Running in GUI mode.");
-			new Gui();
+			new Gui(gameServerLaunchArgs);
 		}
 		
 		// Create log folder
@@ -505,8 +505,8 @@ public class GameServer
 		return START_TIME;
 	}
 	
-	public static void main(String[] args) throws Exception
+	public static void main() throws Exception
 	{
-		new GameServer(args);
+		new GameServer();
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConfigLoader.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConfigLoader.java
@@ -71,8 +71,12 @@ import org.l2jmobius.gameserver.config.custom.WeddingConfig;
  */
 public class ConfigLoader
 {
+	private static String BASE_CONFIG_PATH = "config";
+	
 	public static void init(String baseConfigPath)
 	{
+		BASE_CONFIG_PATH = baseConfigPath;
+		
 		ServerConfig.load(baseConfigPath);
 		
 		// Main configurations.
@@ -133,5 +137,14 @@ public class ConfigLoader
 		WalkerBotProtectionConfig.load(baseConfigPath);
 		WarehouseSortingConfig.load(baseConfigPath);
 		WeddingConfig.load(baseConfigPath);
+	}
+	
+	/**
+	 * Gets the base directory holding the configuration files, as passed to {@link #init(String)}.
+	 * @return the base configuration directory
+	 */
+	public static String getBaseConfigPath()
+	{
+		return BASE_CONFIG_PATH;
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConfigLoader.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConfigLoader.java
@@ -71,67 +71,67 @@ import org.l2jmobius.gameserver.config.custom.WeddingConfig;
  */
 public class ConfigLoader
 {
-	public static void init()
+	public static void init(String baseConfigPath)
 	{
-		ServerConfig.load();
+		ServerConfig.load(baseConfigPath);
 		
 		// Main configurations.
-		ConquerableHallSiegeConfig.load();
-		DevelopmentConfig.load();
-		FeatureConfig.load();
-		FloodProtectorConfig.load();
-		GeneralConfig.load();
-		GeoEngineConfig.load();
-		GrandBossConfig.load();
-		IdManagerConfig.load();
-		NpcConfig.load();
-		OlympiadConfig.load();
-		PlayerConfig.load();
-		PvpConfig.load();
-		RatesConfig.load();
+		ConquerableHallSiegeConfig.load(baseConfigPath);
+		DevelopmentConfig.load(baseConfigPath);
+		FeatureConfig.load(baseConfigPath);
+		FloodProtectorConfig.load(baseConfigPath);
+		GeneralConfig.load(baseConfigPath);
+		GeoEngineConfig.load(baseConfigPath);
+		GrandBossConfig.load(baseConfigPath);
+		IdManagerConfig.load(baseConfigPath);
+		NpcConfig.load(baseConfigPath);
+		OlympiadConfig.load(baseConfigPath);
+		PlayerConfig.load(baseConfigPath);
+		PvpConfig.load(baseConfigPath);
+		RatesConfig.load(baseConfigPath);
 		
 		// Custom configurations.
-		AllowedPlayerRacesConfig.load();
-		AutoPlayConfig.load();
-		AutoPotionsConfig.load();
-		BankingConfig.load();
-		BossAnnouncementsConfig.load();
-		CancelReturnConfig.load();
-		CaptchaConfig.load();
-		ChampionMonstersConfig.load();
-		ChatModerationConfig.load();
-		ClassBalanceConfig.load();
-		CommunityBoardConfig.load();
-		CustomMailManagerConfig.load();
-		DelevelManagerConfig.load();
-		DualboxCheckConfig.load();
-		FactionSystemConfig.load();
-		FakePlayersConfig.load();
-		FindPvpConfig.load();
-		FreeMountsConfig.load();
-		MerchantZeroSellPriceConfig.load();
-		MultilingualSupportConfig.load();
-		NoblessMasterConfig.load();
-		NpcStatMultipliersConfig.load();
-		OfflinePlayConfig.load();
-		OfflineTradeConfig.load();
-		OnlineInfoConfig.load();
-		PasswordChangeConfig.load();
-		PremiumSystemConfig.load();
-		PrivateStoreRangeConfig.load();
-		PvpAnnounceConfig.load();
-		PvpRewardItemConfig.load();
-		PvpTitleColorConfig.load();
-		RandomSpawnsConfig.load();
-		SchemeBufferConfig.load();
-		ScreenWelcomeMessageConfig.load();
-		SellBuffsConfig.load();
-		ServerTimeConfig.load();
-		StartingLocationConfig.load();
-		StartingTitleConfig.load();
-		TransmogConfig.load();
-		WalkerBotProtectionConfig.load();
-		WarehouseSortingConfig.load();
-		WeddingConfig.load();
+		AllowedPlayerRacesConfig.load(baseConfigPath);
+		AutoPlayConfig.load(baseConfigPath);
+		AutoPotionsConfig.load(baseConfigPath);
+		BankingConfig.load(baseConfigPath);
+		BossAnnouncementsConfig.load(baseConfigPath);
+		CancelReturnConfig.load(baseConfigPath);
+		CaptchaConfig.load(baseConfigPath);
+		ChampionMonstersConfig.load(baseConfigPath);
+		ChatModerationConfig.load(baseConfigPath);
+		ClassBalanceConfig.load(baseConfigPath);
+		CommunityBoardConfig.load(baseConfigPath);
+		CustomMailManagerConfig.load(baseConfigPath);
+		DelevelManagerConfig.load(baseConfigPath);
+		DualboxCheckConfig.load(baseConfigPath);
+		FactionSystemConfig.load(baseConfigPath);
+		FakePlayersConfig.load(baseConfigPath);
+		FindPvpConfig.load(baseConfigPath);
+		FreeMountsConfig.load(baseConfigPath);
+		MerchantZeroSellPriceConfig.load(baseConfigPath);
+		MultilingualSupportConfig.load(baseConfigPath);
+		NoblessMasterConfig.load(baseConfigPath);
+		NpcStatMultipliersConfig.load(baseConfigPath);
+		OfflinePlayConfig.load(baseConfigPath);
+		OfflineTradeConfig.load(baseConfigPath);
+		OnlineInfoConfig.load(baseConfigPath);
+		PasswordChangeConfig.load(baseConfigPath);
+		PremiumSystemConfig.load(baseConfigPath);
+		PrivateStoreRangeConfig.load(baseConfigPath);
+		PvpAnnounceConfig.load(baseConfigPath);
+		PvpRewardItemConfig.load(baseConfigPath);
+		PvpTitleColorConfig.load(baseConfigPath);
+		RandomSpawnsConfig.load(baseConfigPath);
+		SchemeBufferConfig.load(baseConfigPath);
+		ScreenWelcomeMessageConfig.load(baseConfigPath);
+		SellBuffsConfig.load(baseConfigPath);
+		ServerTimeConfig.load(baseConfigPath);
+		StartingLocationConfig.load(baseConfigPath);
+		StartingTitleConfig.load(baseConfigPath);
+		TransmogConfig.load(baseConfigPath);
+		WalkerBotProtectionConfig.load(baseConfigPath);
+		WarehouseSortingConfig.load(baseConfigPath);
+		WeddingConfig.load(baseConfigPath);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConquerableHallSiegeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConquerableHallSiegeConfig.java
@@ -39,7 +39,7 @@ public class ConquerableHallSiegeConfig
 	public static int CHS_FAME_AMOUNT;
 	public static int CHS_FAME_FREQUENCY;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CONQUERABLE_HALL_SIEGE_CONFIG_FILE);
 		CHS_MAX_ATTACKERS = config.getInt("MaxAttackers", 500);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConquerableHallSiegeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ConquerableHallSiegeConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class ConquerableHallSiegeConfig
 {
-	// File
-	private static final String CONQUERABLE_HALL_SIEGE_CONFIG_FILE = "./config/ConquerableHallSiege.ini";
-	
 	// Constants
 	public static int CHS_MAX_ATTACKERS;
 	public static int CHS_CLAN_MINLEVEL;
@@ -41,7 +38,8 @@ public class ConquerableHallSiegeConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CONQUERABLE_HALL_SIEGE_CONFIG_FILE);
+		String conquerableHallSiegeConfigFile = String.format("./%s/ConquerableHallSiege.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(conquerableHallSiegeConfigFile);
 		CHS_MAX_ATTACKERS = config.getInt("MaxAttackers", 500);
 		CHS_CLAN_MINLEVEL = config.getInt("MinClanLevel", 4);
 		CHS_MAX_FLAGS_PER_CLAN = config.getInt("MaxFlagsPerClan", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/DevelopmentConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/DevelopmentConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class DevelopmentConfig
 {
-	// File
-	private static final String DEVELOPMENT_CONFIG_FILE = "./config/Development.ini";
-	
 	// Constants
 	public static boolean LOG_SERVER_LOAD_TIMES;
 	public static boolean HTML_ACTION_CACHE_DEBUG;
@@ -49,7 +46,8 @@ public class DevelopmentConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(DEVELOPMENT_CONFIG_FILE);
+		String developmentConfigFile = String.format("./%s/Development.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(developmentConfigFile);
 		LOG_SERVER_LOAD_TIMES = config.getBoolean("LogServerLoadTimes", false);
 		HTML_ACTION_CACHE_DEBUG = config.getBoolean("HtmlActionCacheDebug", false);
 		NO_QUESTS = config.getBoolean("NoQuests", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/DevelopmentConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/DevelopmentConfig.java
@@ -47,7 +47,7 @@ public class DevelopmentConfig
 	public static boolean DEBUG_UNKNOWN_PACKETS;
 	public static Set<String> EXCLUDED_DEBUG_PACKETS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(DEVELOPMENT_CONFIG_FILE);
 		LOG_SERVER_LOAD_TIMES = config.getBoolean("LogServerLoadTimes", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FeatureConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FeatureConfig.java
@@ -206,7 +206,7 @@ public class FeatureConfig
 	public static boolean ALLOW_WYVERN_DURING_SIEGE;
 	public static boolean ALLOW_MOUNTS_DURING_SIEGE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(FEATURE_CONFIG_FILE);
 		CH_TELE_FEE_RATIO = config.getLong("ClanHallTeleportFunctionFeeRatio", 604800000);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FeatureConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FeatureConfig.java
@@ -32,9 +32,6 @@ import org.l2jmobius.commons.util.StringUtil;
  */
 public class FeatureConfig
 {
-	// File
-	private static final String FEATURE_CONFIG_FILE = "./config/Feature.ini";
-	
 	// Constants
 	public static long CH_TELE_FEE_RATIO;
 	public static int CH_TELE1_FEE;
@@ -208,7 +205,8 @@ public class FeatureConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FEATURE_CONFIG_FILE);
+		String featureConfigFile = String.format("./%s/Feature.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(featureConfigFile);
 		CH_TELE_FEE_RATIO = config.getLong("ClanHallTeleportFunctionFeeRatio", 604800000);
 		CH_TELE1_FEE = config.getInt("ClanHallTeleportFunctionFeeLvl1", 7000);
 		CH_TELE2_FEE = config.getInt("ClanHallTeleportFunctionFeeLvl2", 14000);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FloodProtectorConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FloodProtectorConfig.java
@@ -29,9 +29,6 @@ import org.l2jmobius.gameserver.util.FloodProtectorSettings;
  */
 public class FloodProtectorConfig
 {
-	// File
-	private static final String FLOOD_PROTECTOR_CONFIG_FILE = "./config/FloodProtector.ini";
-	
 	// Constants
 	public static FloodProtectorSettings FLOOD_PROTECTOR_USE_ITEM;
 	public static FloodProtectorSettings FLOOD_PROTECTOR_ROLL_DICE;
@@ -52,7 +49,8 @@ public class FloodProtectorConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FLOOD_PROTECTOR_CONFIG_FILE);
+		String floodProtectorConfigFile = String.format("./%s/FloodProtector.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(floodProtectorConfigFile);
 		FLOOD_PROTECTOR_USE_ITEM = new FloodProtectorSettings("UseItemFloodProtector");
 		FLOOD_PROTECTOR_ROLL_DICE = new FloodProtectorSettings("RollDiceFloodProtector");
 		FLOOD_PROTECTOR_ITEM_PET_SUMMON = new FloodProtectorSettings("ItemPetSummonFloodProtector");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FloodProtectorConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/FloodProtectorConfig.java
@@ -50,7 +50,7 @@ public class FloodProtectorConfig
 	public static FloodProtectorSettings FLOOD_PROTECTOR_ITEM_AUCTION;
 	public static FloodProtectorSettings FLOOD_PROTECTOR_PLAYER_ACTION;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(FLOOD_PROTECTOR_CONFIG_FILE);
 		FLOOD_PROTECTOR_USE_ITEM = new FloodProtectorSettings("UseItemFloodProtector");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeneralConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeneralConfig.java
@@ -38,9 +38,6 @@ public class GeneralConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(GeneralConfig.class.getName());
 	
-	// File
-	private static final String GENERAL_CONFIG_FILE = "./config/General.ini";
-	
 	// Constants
 	public static boolean EVERYBODY_HAS_ADMIN_RIGHTS;
 	public static boolean SERVER_GMONLY;
@@ -182,7 +179,8 @@ public class GeneralConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(GENERAL_CONFIG_FILE);
+		String generalConfigFile = String.format("./%s/General.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(generalConfigFile);
 		EVERYBODY_HAS_ADMIN_RIGHTS = config.getBoolean("EverybodyHasAdminRights", false);
 		SERVER_GMONLY = config.getBoolean("ServerGMOnly", false);
 		GM_HERO_AURA = config.getBoolean("GMHeroAura", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeneralConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeneralConfig.java
@@ -180,7 +180,7 @@ public class GeneralConfig
 	public static boolean ENABLE_FALLING_DAMAGE;
 	public static boolean DEBUFF_DURATION_USES_RESISTS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(GENERAL_CONFIG_FILE);
 		EVERYBODY_HAS_ADMIN_RIGHTS = config.getBoolean("EverybodyHasAdminRights", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeoEngineConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeoEngineConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class GeoEngineConfig
 {
-	// File
-	private static final String GEOENGINE_CONFIG_FILE = "./config/GeoEngine.ini";
-	
 	// Constants
 	public static Path GEODATA_PATH;
 	public static Path PATHNODE_PATH;
@@ -50,7 +47,8 @@ public class GeoEngineConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(GEOENGINE_CONFIG_FILE);
+		String geoengineConfigFile = String.format("./%s/GeoEngine.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(geoengineConfigFile);
 		GEODATA_PATH = Paths.get(ServerConfig.DATAPACK_ROOT.getPath() + "/" + config.getString("GeoDataPath", "geodata"));
 		PATHNODE_PATH = Paths.get(ServerConfig.DATAPACK_ROOT.getPath() + "/" + config.getString("PathnodePath", "pathnode"));
 		GEOEDIT_PATH = Paths.get(ServerConfig.DATAPACK_ROOT.getPath() + "/" + config.getString("GeoEditPath", "saves"));

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeoEngineConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GeoEngineConfig.java
@@ -48,7 +48,7 @@ public class GeoEngineConfig
 	public static float DIAGONAL_WEIGHT;
 	public static int MAX_POSTFILTER_PASSES;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(GEOENGINE_CONFIG_FILE);
 		GEODATA_PATH = Paths.get(ServerConfig.DATAPACK_ROOT.getPath() + "/" + config.getString("GeoDataPath", "geodata"));

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GrandBossConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GrandBossConfig.java
@@ -54,7 +54,7 @@ public class GrandBossConfig
 	public static int FRINTEZZA_SPAWN_INTERVAL;
 	public static int FRINTEZZA_SPAWN_RANDOM;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(GRANDBOSS_CONFIG_FILE);
 		ANTHARAS_WAIT_TIME = config.getInt("AntharasWaitTime", 30);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GrandBossConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/GrandBossConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class GrandBossConfig
 {
-	// File
-	private static final String GRANDBOSS_CONFIG_FILE = "./config/GrandBoss.ini";
-	
 	// Constants
 	public static int ANTHARAS_WAIT_TIME;
 	public static int ANTHARAS_SPAWN_INTERVAL;
@@ -56,7 +53,8 @@ public class GrandBossConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(GRANDBOSS_CONFIG_FILE);
+		String grandbossConfigFile = String.format("./%s/GrandBoss.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(grandbossConfigFile);
 		ANTHARAS_WAIT_TIME = config.getInt("AntharasWaitTime", 30);
 		ANTHARAS_SPAWN_INTERVAL = config.getInt("IntervalOfAntharasSpawn", 264);
 		ANTHARAS_SPAWN_RANDOM = config.getInt("RandomOfAntharasSpawn", 72);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/IdManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/IdManagerConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class IdManagerConfig
 {
-	// File
-	private static final String ID_MANAGER_CONFIG_FILE = "./config/IdManager.ini";
-	
 	// Constants
 	public static boolean DATABASE_CLEAN_UP;
 	public static int FIRST_OBJECT_ID;
@@ -41,7 +38,8 @@ public class IdManagerConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(ID_MANAGER_CONFIG_FILE);
+		String idManagerConfigFile = String.format("./%s/IdManager.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(idManagerConfigFile);
 		DATABASE_CLEAN_UP = config.getBoolean("DatabaseCleanUp", true);
 		FIRST_OBJECT_ID = config.getInt("FirstObjectId", 268435456);
 		LAST_OBJECT_ID = config.getInt("LastObjectId", 2147483647);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/IdManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/IdManagerConfig.java
@@ -39,7 +39,7 @@ public class IdManagerConfig
 	public static double RESIZE_THRESHOLD;
 	public static double RESIZE_MULTIPLIER;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(ID_MANAGER_CONFIG_FILE);
 		DATABASE_CLEAN_UP = config.getBoolean("DatabaseCleanUp", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/NpcConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/NpcConfig.java
@@ -81,7 +81,7 @@ public class NpcConfig
 	public static double PET_HP_REGEN_MULTIPLIER;
 	public static double PET_MP_REGEN_MULTIPLIER;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(NPC_CONFIG_FILE);
 		ANNOUNCE_MAMMON_SPAWN = config.getBoolean("AnnounceMammonSpawn", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/NpcConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/NpcConfig.java
@@ -35,9 +35,6 @@ public class NpcConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(NpcConfig.class.getName());
 	
-	// File
-	private static final String NPC_CONFIG_FILE = "./config/NPC.ini";
-	
 	// Constants
 	public static boolean ANNOUNCE_MAMMON_SPAWN;
 	public static boolean ALT_MOB_AGRO_IN_PEACEZONE;
@@ -83,7 +80,8 @@ public class NpcConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(NPC_CONFIG_FILE);
+		String npcConfigFile = String.format("./%s/NPC.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(npcConfigFile);
 		ANNOUNCE_MAMMON_SPAWN = config.getBoolean("AnnounceMammonSpawn", false);
 		ALT_MOB_AGRO_IN_PEACEZONE = config.getBoolean("AltMobAgroInPeaceZone", true);
 		ALT_ATTACKABLE_NPCS = config.getBoolean("AltAttackableNpcs", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/OlympiadConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/OlympiadConfig.java
@@ -33,9 +33,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class OlympiadConfig
 {
-	// File
-	private static final String OLYMPIAD_CONFIG_FILE = "./config/Olympiad.ini";
-	
 	// Constants
 	public static boolean OLYMPIAD_ENABLED;
 	public static int OLYMPIAD_START_TIME;
@@ -70,7 +67,8 @@ public class OlympiadConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(OLYMPIAD_CONFIG_FILE);
+		String olympiadConfigFile = String.format("./%s/Olympiad.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(olympiadConfigFile);
 		OLYMPIAD_ENABLED = config.getBoolean("OlympiadEnabled", true);
 		OLYMPIAD_START_TIME = config.getInt("OlympiadStartTime", 18);
 		OLYMPIAD_MIN = config.getInt("OlympiadMin", 0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/OlympiadConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/OlympiadConfig.java
@@ -68,7 +68,7 @@ public class OlympiadConfig
 	public static int OLYMPIAD_PERIOD_MULTIPLIER;
 	public static List<Integer> OLYMPIAD_COMPETITION_DAYS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(OLYMPIAD_CONFIG_FILE);
 		OLYMPIAD_ENABLED = config.getBoolean("OlympiadEnabled", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PlayerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PlayerConfig.java
@@ -40,9 +40,6 @@ public class PlayerConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(PlayerConfig.class.getName());
 	
-	// File
-	private static final String PLAYER_CONFIG_FILE = "./config/Player.ini";
-	
 	// Constants
 	public static boolean PLAYER_DELEVEL;
 	public static boolean DECREASE_SKILL_LEVEL;
@@ -231,7 +228,8 @@ public class PlayerConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PLAYER_CONFIG_FILE);
+		String playerConfigFile = String.format("./%s/Player.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(playerConfigFile);
 		PLAYER_DELEVEL = config.getBoolean("Delevel", true);
 		DECREASE_SKILL_LEVEL = config.getBoolean("DecreaseSkillOnDelevel", true);
 		ALT_WEIGHT_LIMIT = config.getDouble("AltWeightLimit", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PlayerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PlayerConfig.java
@@ -229,7 +229,7 @@ public class PlayerConfig
 	public static boolean RANDOMIZE_PHYSICAL_SKILL_DAMAGE;
 	public static boolean RANDOMIZE_MAGICAL_SKILL_DAMAGE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PLAYER_CONFIG_FILE);
 		PLAYER_DELEVEL = config.getBoolean("Delevel", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PvpConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PvpConfig.java
@@ -30,9 +30,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PvpConfig
 {
-	// File
-	private static final String PVP_CONFIG_FILE = "./config/PVP.ini";
-	
 	// Constants
 	public static boolean KARMA_DROP_GM;
 	public static boolean KARMA_AWARD_PK_KILL;
@@ -50,7 +47,8 @@ public class PvpConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PVP_CONFIG_FILE);
+		String pvpConfigFile = String.format("./%s/PVP.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(pvpConfigFile);
 		KARMA_DROP_GM = config.getBoolean("CanGMDropEquipment", false);
 		KARMA_AWARD_PK_KILL = config.getBoolean("AwardPKKillPVPPoint", false);
 		KARMA_PK_LIMIT = config.getInt("MinimumPKRequiredToDrop", 5);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PvpConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/PvpConfig.java
@@ -48,7 +48,7 @@ public class PvpConfig
 	public static int PVP_NORMAL_TIME;
 	public static int PVP_PVP_TIME;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PVP_CONFIG_FILE);
 		KARMA_DROP_GM = config.getBoolean("CanGMDropEquipment", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
@@ -39,9 +39,6 @@ public class RatesConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(RatesConfig.class.getName());
 	
-	// File
-	private static final String RATES_CONFIG_FILE = "./config/Rates.ini";
-	
 	// Constants
 	public static float RATE_XP;
 	public static float RATE_SP;
@@ -113,7 +110,8 @@ public class RatesConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(RATES_CONFIG_FILE);
+		String ratesConfigFile = String.format("./%s/Rates.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(ratesConfigFile);
 		RATE_XP = config.getFloat("RateXp", 1);
 		RATE_SP = config.getFloat("RateSp", 1);
 		RATE_PARTY_XP = config.getFloat("RatePartyXp", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/RatesConfig.java
@@ -111,7 +111,7 @@ public class RatesConfig
 	public static int BOSS_DROP_MAX_LEVEL;
 	public static List<DropHolder> BOSS_DROP_LIST = new ArrayList<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(RATES_CONFIG_FILE);
 		RATE_XP = config.getFloat("RateXp", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ServerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ServerConfig.java
@@ -65,10 +65,7 @@ public class ServerConfig
 	private static final Logger LOGGER = Logger.getLogger(ServerConfig.class.getName());
 	
 	// Files
-	private static final String SERVER_CONFIG_FILE = "./config/Server.ini";
-	private static final String IPCONFIG_FILE = "./config/ipconfig.xml";
-	private static final String CHAT_FILTER_FILE = "./config/chatfilter.txt";
-	private static final String HEXID_FILE = "./config/hexid.txt";
+	private static String HEXID_FILE;
 	
 	// Constants
 	public static String GAMESERVER_HOSTNAME;
@@ -117,7 +114,8 @@ public class ServerConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SERVER_CONFIG_FILE);
+		String serverConfigFile = String.format("./%s/Server.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(serverConfigFile);
 		GAMESERVER_HOSTNAME = config.getString("GameserverHostname", "0.0.0.0");
 		PORT_GAME = config.getInt("GameserverPort", 7777);
 		GAME_SERVER_LOGIN_PORT = config.getInt("LoginPort", 9014);
@@ -210,27 +208,29 @@ public class ServerConfig
 		PRECAUTIONARY_RESTART_PERCENTAGE = config.getInt("PrecautionaryRestartPercentage", 95);
 		PRECAUTIONARY_RESTART_DELAY = config.getInt("PrecautionaryRestartDelay", 60) * 1000;
 		
-		final IPConfigData ipConfigData = new IPConfigData();
+		final IPConfigData ipConfigData = new IPConfigData(String.format("./%s/ipconfig.xml", baseConfigPath));
 		GAME_SERVER_SUBNETS = ipConfigData.getSubnets();
 		GAME_SERVER_HOSTS = ipConfigData.getHosts();
 		
 		// Load chatfilter.txt file.
-		loadChatFilter();
+		loadChatFilter(String.format("./%s/chatfilter.txt", baseConfigPath));
 		
 		// Load hexid.txt file.
+		HEXID_FILE = String.format("./%s/hexid.txt", baseConfigPath);
 		loadHexid();
 	}
 	
 	/**
 	 * Loads the chat filter words from the specified file.<br>
-	 * This method reads lines from the {@code CHAT_FILTER_FILE}, trims whitespace and ignores empty lines or lines starting with a '#' character.<br>
+	 * This method reads lines from the given file, trims whitespace and ignores empty lines or lines starting with a '#' character.<br>
 	 * The filtered words are collected into the {@code FILTER_LIST}. If an error occurs during file reading, a warning message is logged.
+	 * @param chatFilterFile path of the chat filter file
 	 */
-	private static void loadChatFilter()
+	private static void loadChatFilter(String chatFilterFile)
 	{
 		try
 		{
-			FILTER_LIST = Files.lines(Paths.get(CHAT_FILTER_FILE), StandardCharsets.UTF_8).map(String::trim).filter(line -> (!line.isEmpty() && (line.charAt(0) != '#'))).collect(Collectors.toList());
+			FILTER_LIST = Files.lines(Paths.get(chatFilterFile), StandardCharsets.UTF_8).map(String::trim).filter(line -> (!line.isEmpty() && (line.charAt(0) != '#'))).collect(Collectors.toList());
 			LOGGER.info("Loaded " + FILTER_LIST.size() + " Filter Words.");
 		}
 		catch (IOException e)
@@ -383,19 +383,22 @@ public class ServerConfig
 		private static final List<String> _subnets = new ArrayList<>(5);
 		private static final List<String> _hosts = new ArrayList<>(5);
 		
-		public IPConfigData()
+		private final String _ipConfigFile;
+		
+		public IPConfigData(String ipConfigFile)
 		{
+			_ipConfigFile = ipConfigFile;
 			load();
 		}
 		
 		@Override
 		public void load()
 		{
-			final File file = new File(IPCONFIG_FILE);
+			final File file = new File(_ipConfigFile);
 			if (file.exists())
 			{
 				LOGGER.info("Network Config: ipconfig.xml exists, using manual configuration...");
-				parseFile(new File(IPCONFIG_FILE));
+				parseFile(file);
 			}
 			else // Auto configuration...
 			{
@@ -422,7 +425,7 @@ public class ServerConfig
 							
 							if (_hosts.size() != _subnets.size())
 							{
-								LOGGER.warning("Failed to Load " + IPCONFIG_FILE + " File - subnets does not match server addresses.");
+								LOGGER.warning("Failed to Load " + _ipConfigFile + " File - subnets does not match server addresses.");
 							}
 						}
 					}
@@ -430,7 +433,7 @@ public class ServerConfig
 					final Node att = n.getAttributes().getNamedItem("address");
 					if (att == null)
 					{
-						LOGGER.warning("Failed to load " + IPCONFIG_FILE + " file - default server address is missing.");
+						LOGGER.warning("Failed to load " + _ipConfigFile + " file - default server address is missing.");
 						_hosts.add("127.0.0.1");
 					}
 					else

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ServerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/ServerConfig.java
@@ -115,7 +115,7 @@ public class ServerConfig
 	public static int SERVER_ID;
 	public static byte[] HEX_ID;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(SERVER_CONFIG_FILE);
 		GAMESERVER_HOSTNAME = config.getString("GameserverHostname", "0.0.0.0");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AllowedPlayerRacesConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AllowedPlayerRacesConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class AllowedPlayerRacesConfig
 {
-	// File
-	private static final String ALLOWED_PLAYER_RACES_CONFIG_FILE = "./config/Custom/AllowedPlayerRaces.ini";
-	
 	// Constants
 	public static boolean ALLOW_HUMAN;
 	public static boolean ALLOW_ELF;
@@ -40,7 +37,8 @@ public class AllowedPlayerRacesConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(ALLOWED_PLAYER_RACES_CONFIG_FILE);
+		String allowedPlayerRacesConfigFile = String.format("./%s/Custom/AllowedPlayerRaces.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(allowedPlayerRacesConfigFile);
 		ALLOW_HUMAN = config.getBoolean("AllowHuman", true);
 		ALLOW_ELF = config.getBoolean("AllowElf", true);
 		ALLOW_DARKELF = config.getBoolean("AllowDarkElf", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AllowedPlayerRacesConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AllowedPlayerRacesConfig.java
@@ -38,7 +38,7 @@ public class AllowedPlayerRacesConfig
 	public static boolean ALLOW_ORC;
 	public static boolean ALLOW_DWARF;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(ALLOWED_PLAYER_RACES_CONFIG_FILE);
 		ALLOW_HUMAN = config.getBoolean("AllowHuman", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPlayConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPlayConfig.java
@@ -49,7 +49,7 @@ public class AutoPlayConfig
 	public static Set<Integer> IGNORED_AUTO_PICK_ITEMS = new HashSet<>();
 	public static String AUTO_PLAY_LOGIN_MESSAGE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(AUTO_PLAY_CONFIG_FILE);
 		ENABLE_AUTO_PLAY = config.getBoolean("EnableAutoPlay", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPlayConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPlayConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class AutoPlayConfig
 {
-	// File
-	private static final String AUTO_PLAY_CONFIG_FILE = "./config/Custom/AutoPlay.ini";
-	
 	// Constants
 	public static boolean ENABLE_AUTO_PLAY;
 	public static boolean ENABLE_AUTO_POTION;
@@ -51,7 +48,8 @@ public class AutoPlayConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(AUTO_PLAY_CONFIG_FILE);
+		String autoPlayConfigFile = String.format("./%s/Custom/AutoPlay.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(autoPlayConfigFile);
 		ENABLE_AUTO_PLAY = config.getBoolean("EnableAutoPlay", false);
 		ENABLE_AUTO_POTION = config.getBoolean("EnableAutoPotion", true);
 		ENABLE_AUTO_SKILL = config.getBoolean("EnableAutoSkill", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPotionsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPotionsConfig.java
@@ -48,7 +48,7 @@ public class AutoPotionsConfig
 	public static Set<Integer> AUTO_HP_ITEM_IDS = new HashSet<>();
 	public static Set<Integer> AUTO_MP_ITEM_IDS = new HashSet<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(AUTO_POTIONS_CONFIG_FILE);
 		AUTO_POTIONS_ENABLED = config.getBoolean("AutoPotionsEnabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPotionsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/AutoPotionsConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class AutoPotionsConfig
 {
-	// File
-	private static final String AUTO_POTIONS_CONFIG_FILE = "./config/Custom/AutoPotions.ini";
-	
 	// Constants
 	public static boolean AUTO_POTIONS_ENABLED;
 	public static boolean AUTO_POTIONS_IN_OLYMPIAD;
@@ -50,7 +47,8 @@ public class AutoPotionsConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(AUTO_POTIONS_CONFIG_FILE);
+		String autoPotionsConfigFile = String.format("./%s/Custom/AutoPotions.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(autoPotionsConfigFile);
 		AUTO_POTIONS_ENABLED = config.getBoolean("AutoPotionsEnabled", false);
 		AUTO_POTIONS_IN_OLYMPIAD = config.getBoolean("AutoPotionsInOlympiad", false);
 		AUTO_POTION_MIN_LEVEL = config.getInt("AutoPotionMinimumLevel", 1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BankingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BankingConfig.java
@@ -36,7 +36,7 @@ public class BankingConfig
 	public static int BANKING_SYSTEM_GOLDBARS;
 	public static int BANKING_SYSTEM_ADENA;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(BANKING_CONFIG_FILE);
 		BANKING_SYSTEM_ENABLED = config.getBoolean("BankingEnabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BankingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BankingConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class BankingConfig
 {
-	// File
-	private static final String BANKING_CONFIG_FILE = "./config/Custom/Banking.ini";
-	
 	// Constants
 	public static boolean BANKING_SYSTEM_ENABLED;
 	public static int BANKING_SYSTEM_GOLDBARS;
@@ -38,7 +35,8 @@ public class BankingConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(BANKING_CONFIG_FILE);
+		String bankingConfigFile = String.format("./%s/Custom/Banking.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(bankingConfigFile);
 		BANKING_SYSTEM_ENABLED = config.getBoolean("BankingEnabled", false);
 		BANKING_SYSTEM_GOLDBARS = config.getInt("BankingGoldbarCount", 1);
 		BANKING_SYSTEM_ADENA = config.getInt("BankingAdenaCount", 500000000);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BossAnnouncementsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BossAnnouncementsConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class BossAnnouncementsConfig
 {
-	// File
-	private static final String BOSS_ANNOUNCEMENTS_CONFIG_FILE = "./config/Custom/BossAnnouncements.ini";
-	
 	// Constants
 	public static boolean RAIDBOSS_SPAWN_ANNOUNCEMENTS;
 	public static boolean RAIDBOSS_DEFEAT_ANNOUNCEMENTS;
@@ -46,7 +43,8 @@ public class BossAnnouncementsConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(BOSS_ANNOUNCEMENTS_CONFIG_FILE);
+		String bossAnnouncementsConfigFile = String.format("./%s/Custom/BossAnnouncements.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(bossAnnouncementsConfigFile);
 		RAIDBOSS_SPAWN_ANNOUNCEMENTS = config.getBoolean("RaidBossSpawnAnnouncements", false);
 		RAIDBOSS_DEFEAT_ANNOUNCEMENTS = config.getBoolean("RaidBossDefeatAnnouncements", false);
 		RAIDBOSS_INSTANCE_ANNOUNCEMENTS = config.getBoolean("RaidBossInstanceAnnouncements", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BossAnnouncementsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/BossAnnouncementsConfig.java
@@ -44,7 +44,7 @@ public class BossAnnouncementsConfig
 	public static Set<Integer> RAIDBOSSES_EXCLUDED_FROM_SPAWN_ANNOUNCEMENTS = new HashSet<>();
 	public static Set<Integer> RAIDBOSSES_EXCLUDED_FROM_DEFEAT_ANNOUNCEMENTS = new HashSet<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(BOSS_ANNOUNCEMENTS_CONFIG_FILE);
 		RAIDBOSS_SPAWN_ANNOUNCEMENTS = config.getBoolean("RaidBossSpawnAnnouncements", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CancelReturnConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CancelReturnConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class CancelReturnConfig
 {
-	// File
-	private static final String CANCEL_RETURN_CONFIG_FILE = "./config/Custom/CancelReturn.ini";
-	
 	// Constants
 	public static boolean CANCEL_RETURN_ON;
 	public static boolean CANCEL_RETURN_MOB;
@@ -40,7 +37,8 @@ public class CancelReturnConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CANCEL_RETURN_CONFIG_FILE);
+		String cancelReturnConfigFile = String.format("./%s/Custom/CancelReturn.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(cancelReturnConfigFile);
 		CANCEL_RETURN_ON = config.getBoolean("CancelReturn", false);
 		CANCEL_RETURN_MOB = config.getBoolean("ReturnMonster", true);
 		CANCEL_RETURN_PLAYER = config.getBoolean("ReturnPlayer", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CancelReturnConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CancelReturnConfig.java
@@ -38,7 +38,7 @@ public class CancelReturnConfig
 	public static boolean CANCEL_RETURN_PLAYER_OLYS;
 	public static int TIME_TO_RETURN;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CANCEL_RETURN_CONFIG_FILE);
 		CANCEL_RETURN_ON = config.getBoolean("CancelReturn", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CaptchaConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CaptchaConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class CaptchaConfig
 {
-	// File
-	private static final String CAPTCHA_CONFIG_FILE = "./config/Custom/Captcha.ini";
-	
 	// Constants
 	public static boolean ENABLE_CAPTCHA;
 	public static int KILL_COUNTER;
@@ -45,7 +42,8 @@ public class CaptchaConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CAPTCHA_CONFIG_FILE);
+		String captchaConfigFile = String.format("./%s/Custom/Captcha.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(captchaConfigFile);
 		ENABLE_CAPTCHA = config.getBoolean("EnableCaptcha", false);
 		KILL_COUNTER = config.getInt("KillCounter", 100);
 		KILL_COUNTER_RANDOMIZATION = config.getInt("KillCounterRandomization", 50);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CaptchaConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CaptchaConfig.java
@@ -43,7 +43,7 @@ public class CaptchaConfig
 	public static int JAIL_TIME;
 	public static boolean DOUBLE_JAIL_TIME;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CAPTCHA_CONFIG_FILE);
 		ENABLE_CAPTCHA = config.getBoolean("EnableCaptcha", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChampionMonstersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChampionMonstersConfig.java
@@ -58,7 +58,7 @@ public class ChampionMonstersConfig
 	public static boolean CHAMPION_ENABLE_VITALITY;
 	public static boolean CHAMPION_ENABLE_IN_INSTANCES;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CHAMPION_MONSTERS_CONFIG_FILE);
 		CHAMPION_ENABLE = config.getBoolean("ChampionEnable", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChampionMonstersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChampionMonstersConfig.java
@@ -32,9 +32,6 @@ import org.l2jmobius.gameserver.model.item.holders.ItemHolder;
  */
 public class ChampionMonstersConfig
 {
-	// File
-	private static final String CHAMPION_MONSTERS_CONFIG_FILE = "./config/Custom/ChampionMonsters.ini";
-	
 	// Constants
 	public static boolean CHAMPION_ENABLE;
 	public static boolean CHAMPION_PASSIVE;
@@ -60,7 +57,8 @@ public class ChampionMonstersConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CHAMPION_MONSTERS_CONFIG_FILE);
+		String championMonstersConfigFile = String.format("./%s/Custom/ChampionMonsters.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(championMonstersConfigFile);
 		CHAMPION_ENABLE = config.getBoolean("ChampionEnable", false);
 		CHAMPION_PASSIVE = config.getBoolean("ChampionPassive", false);
 		CHAMPION_FREQUENCY = config.getInt("ChampionFrequency", 0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChatModerationConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChatModerationConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class ChatModerationConfig
 {
-	// File
-	private static final String CHAT_MODERATION_CONFIG_FILE = "./config/Custom/ChatModeration.ini";
-	
 	// Constants
 	public static boolean CHAT_ADMIN;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CHAT_MODERATION_CONFIG_FILE);
+		String chatModerationConfigFile = String.format("./%s/Custom/ChatModeration.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(chatModerationConfigFile);
 		CHAT_ADMIN = config.getBoolean("ChatAdmin", true);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChatModerationConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ChatModerationConfig.java
@@ -34,7 +34,7 @@ public class ChatModerationConfig
 	// Constants
 	public static boolean CHAT_ADMIN;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CHAT_MODERATION_CONFIG_FILE);
 		CHAT_ADMIN = config.getBoolean("ChatAdmin", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ClassBalanceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ClassBalanceConfig.java
@@ -74,7 +74,7 @@ public class ClassBalanceConfig
 	public static float[] EXP_AMOUNT_MULTIPLIERS = new float[119];
 	public static float[] SP_AMOUNT_MULTIPLIERS = new float[119];
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(CLASS_BALANCE_CONFIG_FILE);
 		

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ClassBalanceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ClassBalanceConfig.java
@@ -32,9 +32,6 @@ import org.l2jmobius.gameserver.model.actor.enums.player.PlayerClass;
  */
 public class ClassBalanceConfig
 {
-	// File
-	private static final String CLASS_BALANCE_CONFIG_FILE = "./config/Custom/ClassBalance.ini";
-	
 	// Constants
 	public static float[] PVE_MAGICAL_SKILL_DAMAGE_MULTIPLIERS = new float[119];
 	public static float[] PVP_MAGICAL_SKILL_DAMAGE_MULTIPLIERS = new float[119];
@@ -76,7 +73,8 @@ public class ClassBalanceConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(CLASS_BALANCE_CONFIG_FILE);
+		String classBalanceConfigFile = String.format("./%s/Custom/ClassBalance.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(classBalanceConfigFile);
 		
 		Arrays.fill(PVE_MAGICAL_SKILL_DAMAGE_MULTIPLIERS, 1f);
 		final String[] pveMagicalSkillDamageMultipliers = config.getString("PveMagicalSkillDamageMultipliers", "").trim().split(";");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CommunityBoardConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CommunityBoardConfig.java
@@ -34,9 +34,6 @@ import org.l2jmobius.gameserver.model.Location;
  */
 public class CommunityBoardConfig
 {
-	// File
-	private static final String COMMUNITY_BOARD_CONFIG_FILE = "./config/Custom/CommunityBoard.ini";
-	
 	// Constants
 	public static boolean CUSTOM_CB_ENABLED;
 	public static int COMMUNITYBOARD_CURRENCY;
@@ -61,7 +58,8 @@ public class CommunityBoardConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(COMMUNITY_BOARD_CONFIG_FILE);
+		String communityBoardConfigFile = String.format("./%s/Custom/CommunityBoard.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(communityBoardConfigFile);
 		CUSTOM_CB_ENABLED = config.getBoolean("CustomCommunityBoard", false);
 		COMMUNITYBOARD_CURRENCY = config.getInt("CommunityCurrencyId", 57);
 		COMMUNITYBOARD_ENABLE_MULTISELLS = config.getBoolean("CommunityEnableMultisells", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CommunityBoardConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CommunityBoardConfig.java
@@ -59,7 +59,7 @@ public class CommunityBoardConfig
 	public static Set<Integer> COMMUNITY_AVAILABLE_BUFFS;
 	public static Map<String, Location> COMMUNITY_AVAILABLE_TELEPORTS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(COMMUNITY_BOARD_CONFIG_FILE);
 		CUSTOM_CB_ENABLED = config.getBoolean("CustomCommunityBoard", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CustomMailManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CustomMailManagerConfig.java
@@ -28,16 +28,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class CustomMailManagerConfig
 {
-	// File
-	private static final String CUSTOM_MAIL_MANAGER_CONFIG_FILE = "./config/Custom/CustomMailManager.ini";
-	
 	// Constants
 	public static boolean CUSTOM_MAIL_MANAGER_ENABLED;
 	public static int CUSTOM_MAIL_MANAGER_DELAY;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader custom = new ConfigReader(CUSTOM_MAIL_MANAGER_CONFIG_FILE);
+		String customMailManagerConfigFile = String.format("./%s/Custom/CustomMailManager.ini", baseConfigPath);
+		final ConfigReader custom = new ConfigReader(customMailManagerConfigFile);
 		CUSTOM_MAIL_MANAGER_ENABLED = custom.getBoolean("CustomMailManagerEnabled", false);
 		CUSTOM_MAIL_MANAGER_DELAY = custom.getInt("DatabaseQueryDelay", 30) * 1000;
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CustomMailManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/CustomMailManagerConfig.java
@@ -35,7 +35,7 @@ public class CustomMailManagerConfig
 	public static boolean CUSTOM_MAIL_MANAGER_ENABLED;
 	public static int CUSTOM_MAIL_MANAGER_DELAY;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader custom = new ConfigReader(CUSTOM_MAIL_MANAGER_CONFIG_FILE);
 		CUSTOM_MAIL_MANAGER_ENABLED = custom.getBoolean("CustomMailManagerEnabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DelevelManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DelevelManagerConfig.java
@@ -38,7 +38,7 @@ public class DelevelManagerConfig
 	public static int DELEVEL_MANAGER_ITEMCOUNT;
 	public static int DELEVEL_MANAGER_MINIMUM_DELEVEL;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(DELEVEL_MANAGER_CONFIG_FILE);
 		DELEVEL_MANAGER_ENABLED = config.getBoolean("Enabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DelevelManagerConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DelevelManagerConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class DelevelManagerConfig
 {
-	// File
-	private static final String DELEVEL_MANAGER_CONFIG_FILE = "./config/Custom/DelevelManager.ini";
-	
 	// Constants
 	public static boolean DELEVEL_MANAGER_ENABLED;
 	public static int DELEVEL_MANAGER_NPCID;
@@ -40,7 +37,8 @@ public class DelevelManagerConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(DELEVEL_MANAGER_CONFIG_FILE);
+		String delevelManagerConfigFile = String.format("./%s/Custom/DelevelManager.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(delevelManagerConfigFile);
 		DELEVEL_MANAGER_ENABLED = config.getBoolean("Enabled", false);
 		DELEVEL_MANAGER_NPCID = config.getInt("NpcId", 1002000);
 		DELEVEL_MANAGER_ITEMID = config.getInt("RequiredItemId", 4356);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DualboxCheckConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DualboxCheckConfig.java
@@ -49,7 +49,7 @@ public class DualboxCheckConfig
 	public static boolean DUALBOX_COUNT_OFFLINE_TRADERS;
 	public static Map<Integer, Integer> DUALBOX_CHECK_WHITELIST;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(DUALBOX_CHECK_CONFIG_FILE);
 		DUALBOX_CHECK_MAX_PLAYERS_PER_IP = config.getInt("DualboxCheckMaxPlayersPerIP", 0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DualboxCheckConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/DualboxCheckConfig.java
@@ -37,9 +37,6 @@ public class DualboxCheckConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(DualboxCheckConfig.class.getName());
 	
-	// File
-	private static final String DUALBOX_CHECK_CONFIG_FILE = "./config/Custom/DualboxCheck.ini";
-	
 	// Constants
 	public static int DUALBOX_CHECK_MAX_PLAYERS_PER_IP;
 	public static int DUALBOX_CHECK_MAX_OLYMPIAD_PARTICIPANTS_PER_IP;
@@ -51,7 +48,8 @@ public class DualboxCheckConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(DUALBOX_CHECK_CONFIG_FILE);
+		String dualboxCheckConfigFile = String.format("./%s/Custom/DualboxCheck.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(dualboxCheckConfigFile);
 		DUALBOX_CHECK_MAX_PLAYERS_PER_IP = config.getInt("DualboxCheckMaxPlayersPerIP", 0);
 		DUALBOX_CHECK_MAX_OLYMPIAD_PARTICIPANTS_PER_IP = config.getInt("DualboxCheckMaxOlympiadParticipantsPerIP", 0);
 		DUALBOX_CHECK_MAX_L2EVENT_PARTICIPANTS_PER_IP = config.getInt("DualboxCheckMaxL2EventParticipantsPerIP", 0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FactionSystemConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FactionSystemConfig.java
@@ -29,9 +29,6 @@ import org.l2jmobius.gameserver.model.Location;
  */
 public class FactionSystemConfig
 {
-	// File
-	private static final String FACTION_SYSTEM_CONFIG_FILE = "./config/Custom/FactionSystem.ini";
-	
 	// Constants
 	public static boolean FACTION_SYSTEM_ENABLED;
 	public static Location FACTION_STARTING_LOCATION;
@@ -49,9 +46,10 @@ public class FactionSystemConfig
 	public static boolean FACTION_BALANCE_ONLINE_PLAYERS;
 	public static int FACTION_BALANCE_PLAYER_EXCEED_LIMIT;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FACTION_SYSTEM_CONFIG_FILE);
+		String factionSystemConfigFile = String.format("./%s/Custom/FactionSystem.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(factionSystemConfigFile);
 		String[] tempString;
 		FACTION_SYSTEM_ENABLED = config.getBoolean("EnableFactionSystem", false);
 		tempString = config.getString("StartingLocation", "85332,16199,-1252").split(",");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FakePlayersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FakePlayersConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class FakePlayersConfig
 {
-	// File
-	private static final String FAKE_PLAYERS_CONFIG_FILE = "./config/Custom/FakePlayers.ini";
-	
 	// Constants
 	public static boolean FAKE_PLAYERS_ENABLED;
 	public static boolean FAKE_PLAYER_CHAT;
@@ -59,7 +56,8 @@ public class FakePlayersConfig
 
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FAKE_PLAYERS_CONFIG_FILE);
+		String fakePlayersConfigFile = String.format("./%s/Custom/FakePlayers.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(fakePlayersConfigFile);
 		FAKE_PLAYERS_ENABLED = config.getBoolean("EnableFakePlayers", false);
 		FAKE_PLAYER_CHAT = config.getBoolean("FakePlayerChat", false);
 		FAKE_PLAYER_BEHAVIOR = config.getBoolean("FakePlayerBehavior", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FakePlayersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FakePlayersConfig.java
@@ -57,7 +57,7 @@ public class FakePlayersConfig
 	public static boolean PHANTOM_HUNTER_PLAYSTYLES;
 	public static boolean PHANTOM_HUNTER_RETALIATE;
 
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(FAKE_PLAYERS_CONFIG_FILE);
 		FAKE_PLAYERS_ENABLED = config.getBoolean("EnableFakePlayers", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FindPvpConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FindPvpConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class FindPvpConfig
 {
-	// File
-	private static final String FIND_PVP_CONFIG_FILE = "./config/Custom/FindPvP.ini";
-	
 	// Constants
 	public static boolean ENABLE_FIND_PVP;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FIND_PVP_CONFIG_FILE);
+		String findPvpConfigFile = String.format("./%s/Custom/FindPvP.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(findPvpConfigFile);
 		ENABLE_FIND_PVP = config.getBoolean("EnableFindPvP", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FindPvpConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FindPvpConfig.java
@@ -34,7 +34,7 @@ public class FindPvpConfig
 	// Constants
 	public static boolean ENABLE_FIND_PVP;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(FIND_PVP_CONFIG_FILE);
 		ENABLE_FIND_PVP = config.getBoolean("EnableFindPvP", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FreeMountsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FreeMountsConfig.java
@@ -28,16 +28,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class FreeMountsConfig
 {
-	// File
-	private static final String FREE_MOUNTS_CONFIG_FILE = "./config/Custom/FreeMounts.ini";
-	
 	// Constants
 	public static boolean ENABLE_FREE_STRIDER;
 	public static boolean ENABLE_FREE_WYVERN;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(FREE_MOUNTS_CONFIG_FILE);
+		String freeMountsConfigFile = String.format("./%s/Custom/FreeMounts.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(freeMountsConfigFile);
 		ENABLE_FREE_STRIDER = config.getBoolean("EnableFreeStrider", false);
 		ENABLE_FREE_WYVERN = config.getBoolean("EnableFreeWyvern", false);
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FreeMountsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/FreeMountsConfig.java
@@ -35,7 +35,7 @@ public class FreeMountsConfig
 	public static boolean ENABLE_FREE_STRIDER;
 	public static boolean ENABLE_FREE_WYVERN;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(FREE_MOUNTS_CONFIG_FILE);
 		ENABLE_FREE_STRIDER = config.getBoolean("EnableFreeStrider", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MerchantZeroSellPriceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MerchantZeroSellPriceConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class MerchantZeroSellPriceConfig
 {
-	// File
-	private static final String MERCHANT_ZERO_SELL_PRICE_CONFIG_FILE = "./config/Custom/MerchantZeroSellPrice.ini";
-	
 	// Constants
 	public static boolean MERCHANT_ZERO_SELL_PRICE;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(MERCHANT_ZERO_SELL_PRICE_CONFIG_FILE);
+		String merchantZeroSellPriceConfigFile = String.format("./%s/Custom/MerchantZeroSellPrice.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(merchantZeroSellPriceConfigFile);
 		MERCHANT_ZERO_SELL_PRICE = config.getBoolean("MerchantZeroSellPrice", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MerchantZeroSellPriceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MerchantZeroSellPriceConfig.java
@@ -34,7 +34,7 @@ public class MerchantZeroSellPriceConfig
 	// Constants
 	public static boolean MERCHANT_ZERO_SELL_PRICE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(MERCHANT_ZERO_SELL_PRICE_CONFIG_FILE);
 		MERCHANT_ZERO_SELL_PRICE = config.getBoolean("MerchantZeroSellPrice", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MultilingualSupportConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MultilingualSupportConfig.java
@@ -35,9 +35,6 @@ public class MultilingualSupportConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(MultilingualSupportConfig.class.getName());
 	
-	// File
-	private static final String MULTILANGUAL_SUPPORT_CONFIG_FILE = "./config/Custom/MultilingualSupport.ini";
-	
 	// Constants
 	public static String MULTILANG_DEFAULT;
 	public static boolean MULTILANG_ENABLE;
@@ -46,7 +43,8 @@ public class MultilingualSupportConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(MULTILANGUAL_SUPPORT_CONFIG_FILE);
+		String multilangualSupportConfigFile = String.format("./%s/Custom/MultilingualSupport.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(multilangualSupportConfigFile);
 		MULTILANG_DEFAULT = config.getString("MultiLangDefault", "en").toLowerCase();
 		
 		MULTILANG_ENABLE = config.getBoolean("MultiLangEnable", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MultilingualSupportConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/MultilingualSupportConfig.java
@@ -44,7 +44,7 @@ public class MultilingualSupportConfig
 	public static List<String> MULTILANG_ALLOWED = new ArrayList<>();
 	public static boolean MULTILANG_VOICED_ALLOW;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(MULTILANGUAL_SUPPORT_CONFIG_FILE);
 		MULTILANG_DEFAULT = config.getString("MultiLangDefault", "en").toLowerCase();

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NoblessMasterConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NoblessMasterConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class NoblessMasterConfig
 {
-	// File
-	private static final String NOBLESS_MASTER_CONFIG_FILE = "./config/Custom/NoblessMaster.ini";
-	
 	// Constants
 	public static boolean NOBLESS_MASTER_ENABLED;
 	public static int NOBLESS_MASTER_NPCID;
@@ -41,7 +38,8 @@ public class NoblessMasterConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(NOBLESS_MASTER_CONFIG_FILE);
+		String noblessMasterConfigFile = String.format("./%s/Custom/NoblessMaster.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(noblessMasterConfigFile);
 		NOBLESS_MASTER_ENABLED = config.getBoolean("Enabled", false);
 		NOBLESS_MASTER_NPCID = config.getInt("NpcId", 1003000);
 		NOBLESS_MASTER_LEVEL_REQUIREMENT = config.getInt("LevelRequirement", 80);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NoblessMasterConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NoblessMasterConfig.java
@@ -39,7 +39,7 @@ public class NoblessMasterConfig
 	public static int NOBLESS_MASTER_ITEM_COUNT;
 	public static boolean NOBLESS_MASTER_REWARD_TIARA;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(NOBLESS_MASTER_CONFIG_FILE);
 		NOBLESS_MASTER_ENABLED = config.getBoolean("Enabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NpcStatMultipliersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NpcStatMultipliersConfig.java
@@ -66,7 +66,7 @@ public class NpcStatMultipliersConfig
 	public static double DEFENDER_AGRRO_RANGE_MULTIPLIER;
 	public static double DEFENDER_CLAN_HELP_RANGE_MULTIPLIER;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(NPC_STAT_MULTIPLIERS_CONFIG_FILE);
 		ENABLE_NPC_STAT_MULTIPLIERS = config.getBoolean("EnableNpcStatMultipliers", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NpcStatMultipliersConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/NpcStatMultipliersConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class NpcStatMultipliersConfig
 {
-	// File
-	private static final String NPC_STAT_MULTIPLIERS_CONFIG_FILE = "./config/Custom/NpcStatMultipliers.ini";
-	
 	// Constants
 	public static boolean ENABLE_NPC_STAT_MULTIPLIERS;
 	public static double MONSTER_HP_MULTIPLIER;
@@ -68,7 +65,8 @@ public class NpcStatMultipliersConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(NPC_STAT_MULTIPLIERS_CONFIG_FILE);
+		String npcStatMultipliersConfigFile = String.format("./%s/Custom/NpcStatMultipliers.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(npcStatMultipliersConfigFile);
 		ENABLE_NPC_STAT_MULTIPLIERS = config.getBoolean("EnableNpcStatMultipliers", false);
 		MONSTER_HP_MULTIPLIER = config.getDouble("MonsterHP", 1.0);
 		MONSTER_MP_MULTIPLIER = config.getDouble("MonsterMP", 1.0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflinePlayConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflinePlayConfig.java
@@ -32,9 +32,6 @@ import org.l2jmobius.gameserver.model.skill.AbnormalVisualEffect;
  */
 public class OfflinePlayConfig
 {
-	// File
-	private static final String OFFLINE_PLAY_CONFIG_FILE = "./config/Custom/OfflinePlay.ini";
-	
 	// Constants
 	public static boolean ENABLE_OFFLINE_PLAY_COMMAND;
 	public static boolean RESTORE_AUTO_PLAY_OFFLINERS;
@@ -48,7 +45,8 @@ public class OfflinePlayConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(OFFLINE_PLAY_CONFIG_FILE);
+		String offlinePlayConfigFile = String.format("./%s/Custom/OfflinePlay.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(offlinePlayConfigFile);
 		ENABLE_OFFLINE_PLAY_COMMAND = config.getBoolean("EnableOfflinePlayCommand", false);
 		RESTORE_AUTO_PLAY_OFFLINERS = config.getBoolean("RestoreAutoPlayOffliners", true);
 		OFFLINE_PLAY_PREMIUM = config.getBoolean("OfflinePlayPremium", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflinePlayConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflinePlayConfig.java
@@ -46,7 +46,7 @@ public class OfflinePlayConfig
 	public static int OFFLINE_PLAY_NAME_COLOR;
 	public static List<AbnormalVisualEffect> OFFLINE_PLAY_ABNORMAL_EFFECTS = new ArrayList<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(OFFLINE_PLAY_CONFIG_FILE);
 		ENABLE_OFFLINE_PLAY_COMMAND = config.getBoolean("EnableOfflinePlayCommand", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflineTradeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflineTradeConfig.java
@@ -51,7 +51,7 @@ public class OfflineTradeConfig
 	public static boolean ENABLE_OFFLINE_COMMAND;
 	public static List<AbnormalVisualEffect> OFFLINE_ABNORMAL_EFFECTS = new ArrayList<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(OFFLINE_TRADE_CONFIG_FILE);
 		OFFLINE_TRADE_ENABLE = config.getBoolean("OfflineTradeEnable", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflineTradeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OfflineTradeConfig.java
@@ -32,9 +32,6 @@ import org.l2jmobius.gameserver.model.skill.AbnormalVisualEffect;
  */
 public class OfflineTradeConfig
 {
-	// File
-	private static final String OFFLINE_TRADE_CONFIG_FILE = "./config/Custom/OfflineTrade.ini";
-	
 	// Constants
 	public static boolean OFFLINE_TRADE_ENABLE;
 	public static boolean OFFLINE_CRAFT_ENABLE;
@@ -53,7 +50,8 @@ public class OfflineTradeConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(OFFLINE_TRADE_CONFIG_FILE);
+		String offlineTradeConfigFile = String.format("./%s/Custom/OfflineTrade.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(offlineTradeConfigFile);
 		OFFLINE_TRADE_ENABLE = config.getBoolean("OfflineTradeEnable", false);
 		OFFLINE_CRAFT_ENABLE = config.getBoolean("OfflineCraftEnable", false);
 		OFFLINE_MODE_IN_PEACE_ZONE = config.getBoolean("OfflineModeInPeaceZone", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OnlineInfoConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OnlineInfoConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class OnlineInfoConfig
 {
-	// File
-	private static final String ONLINE_INFO_CONFIG_FILE = "./config/Custom/OnlineInfo.ini";
-	
 	// Constants
 	public static boolean ENABLE_ONLINE_COMMAND;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(ONLINE_INFO_CONFIG_FILE);
+		String onlineInfoConfigFile = String.format("./%s/Custom/OnlineInfo.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(onlineInfoConfigFile);
 		ENABLE_ONLINE_COMMAND = config.getBoolean("EnableOnlineCommand", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OnlineInfoConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/OnlineInfoConfig.java
@@ -34,7 +34,7 @@ public class OnlineInfoConfig
 	// Constants
 	public static boolean ENABLE_ONLINE_COMMAND;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(ONLINE_INFO_CONFIG_FILE);
 		ENABLE_ONLINE_COMMAND = config.getBoolean("EnableOnlineCommand", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PasswordChangeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PasswordChangeConfig.java
@@ -34,7 +34,7 @@ public class PasswordChangeConfig
 	// Constants
 	public static boolean ALLOW_CHANGE_PASSWORD;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PASSWORD_CHANGE_CONFIG_FILE);
 		ALLOW_CHANGE_PASSWORD = config.getBoolean("AllowChangePassword", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PasswordChangeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PasswordChangeConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PasswordChangeConfig
 {
-	// File
-	private static final String PASSWORD_CHANGE_CONFIG_FILE = "./config/Custom/PasswordChange.ini";
-	
 	// Constants
 	public static boolean ALLOW_CHANGE_PASSWORD;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PASSWORD_CHANGE_CONFIG_FILE);
+		String passwordChangeConfigFile = String.format("./%s/Custom/PasswordChange.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(passwordChangeConfigFile);
 		ALLOW_CHANGE_PASSWORD = config.getBoolean("AllowChangePassword", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PremiumSystemConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PremiumSystemConfig.java
@@ -34,9 +34,6 @@ public class PremiumSystemConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(PremiumSystemConfig.class.getName());
 	
-	// File
-	private static final String PREMIUM_SYSTEM_CONFIG_FILE = "./config/Custom/PremiumSystem.ini";
-	
 	// Constants
 	public static boolean PREMIUM_SYSTEM_ENABLED;
 	public static boolean PC_CAFE_ENABLED;
@@ -64,7 +61,8 @@ public class PremiumSystemConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PREMIUM_SYSTEM_CONFIG_FILE);
+		String premiumSystemConfigFile = String.format("./%s/Custom/PremiumSystem.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(premiumSystemConfigFile);
 		PREMIUM_SYSTEM_ENABLED = config.getBoolean("EnablePremiumSystem", false);
 		PC_CAFE_ENABLED = config.getBoolean("PcCafeEnabled", false);
 		PC_CAFE_ONLY_PREMIUM = config.getBoolean("PcCafeOnlyPremium", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PremiumSystemConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PremiumSystemConfig.java
@@ -62,7 +62,7 @@ public class PremiumSystemConfig
 	public static Map<Integer, Float> PREMIUM_RATE_DROP_CHANCE_BY_ID;
 	public static Map<Integer, Float> PREMIUM_RATE_DROP_AMOUNT_BY_ID;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PREMIUM_SYSTEM_CONFIG_FILE);
 		PREMIUM_SYSTEM_ENABLED = config.getBoolean("EnablePremiumSystem", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PrivateStoreRangeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PrivateStoreRangeConfig.java
@@ -28,16 +28,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PrivateStoreRangeConfig
 {
-	// File
-	private static final String PRIVATE_STORE_RANGE_CONFIG_FILE = "./config/Custom/PrivateStoreRange.ini";
-	
 	// Constants
 	public static int SHOP_MIN_RANGE_FROM_PLAYER;
 	public static int SHOP_MIN_RANGE_FROM_NPC;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PRIVATE_STORE_RANGE_CONFIG_FILE);
+		String privateStoreRangeConfigFile = String.format("./%s/Custom/PrivateStoreRange.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(privateStoreRangeConfigFile);
 		SHOP_MIN_RANGE_FROM_PLAYER = config.getInt("ShopMinRangeFromPlayer", 50);
 		SHOP_MIN_RANGE_FROM_NPC = config.getInt("ShopMinRangeFromNpc", 100);
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PrivateStoreRangeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PrivateStoreRangeConfig.java
@@ -35,7 +35,7 @@ public class PrivateStoreRangeConfig
 	public static int SHOP_MIN_RANGE_FROM_PLAYER;
 	public static int SHOP_MIN_RANGE_FROM_NPC;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PRIVATE_STORE_RANGE_CONFIG_FILE);
 		SHOP_MIN_RANGE_FROM_PLAYER = config.getInt("ShopMinRangeFromPlayer", 50);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpAnnounceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpAnnounceConfig.java
@@ -37,7 +37,7 @@ public class PvpAnnounceConfig
 	public static String ANNOUNCE_PK_MSG;
 	public static String ANNOUNCE_PVP_MSG;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PVP_ANNOUNCE_CONFIG_FILE);
 		ANNOUNCE_PK_PVP = config.getBoolean("AnnouncePkPvP", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpAnnounceConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpAnnounceConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PvpAnnounceConfig
 {
-	// File
-	private static final String PVP_ANNOUNCE_CONFIG_FILE = "./config/Custom/PvpAnnounce.ini";
-	
 	// Constants
 	public static boolean ANNOUNCE_PK_PVP;
 	public static boolean ANNOUNCE_PK_PVP_NORMAL_MESSAGE;
@@ -39,7 +36,8 @@ public class PvpAnnounceConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PVP_ANNOUNCE_CONFIG_FILE);
+		String pvpAnnounceConfigFile = String.format("./%s/Custom/PvpAnnounce.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(pvpAnnounceConfigFile);
 		ANNOUNCE_PK_PVP = config.getBoolean("AnnouncePkPvP", false);
 		ANNOUNCE_PK_PVP_NORMAL_MESSAGE = config.getBoolean("AnnouncePkPvPNormalMessage", true);
 		ANNOUNCE_PK_MSG = config.getString("AnnouncePkMsg", "$killer has slaughtered $target");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpRewardItemConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpRewardItemConfig.java
@@ -43,7 +43,7 @@ public class PvpRewardItemConfig
 	public static boolean DISABLE_REWARDS_IN_INSTANCES;
 	public static boolean DISABLE_REWARDS_IN_PVP_ZONES;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PVP_REWARD_ITEM_CONFIG_FILE);
 		REWARD_PVP_ITEM = config.getBoolean("RewardPvpItem", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpRewardItemConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpRewardItemConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PvpRewardItemConfig
 {
-	// File
-	private static final String PVP_REWARD_ITEM_CONFIG_FILE = "./config/Custom/PvpRewardItem.ini";
-	
 	// Constants
 	public static boolean REWARD_PVP_ITEM;
 	public static int REWARD_PVP_ITEM_ID;
@@ -45,7 +42,8 @@ public class PvpRewardItemConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PVP_REWARD_ITEM_CONFIG_FILE);
+		String pvpRewardItemConfigFile = String.format("./%s/Custom/PvpRewardItem.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(pvpRewardItemConfigFile);
 		REWARD_PVP_ITEM = config.getBoolean("RewardPvpItem", false);
 		REWARD_PVP_ITEM_ID = config.getInt("RewardPvpItemId", 57);
 		REWARD_PVP_ITEM_AMOUNT = config.getInt("RewardPvpItemAmount", 1000);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpTitleColorConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpTitleColorConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class PvpTitleColorConfig
 {
-	// File
-	private static final String PVP_TITLE_CONFIG_FILE = "./config/Custom/PvpTitleColor.ini";
-	
 	// Constants
 	public static boolean PVP_COLOR_SYSTEM_ENABLED;
 	public static int PVP_AMOUNT1;
@@ -51,7 +48,8 @@ public class PvpTitleColorConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(PVP_TITLE_CONFIG_FILE);
+		String pvpTitleConfigFile = String.format("./%s/Custom/PvpTitleColor.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(pvpTitleConfigFile);
 		PVP_COLOR_SYSTEM_ENABLED = config.getBoolean("EnablePvPColorSystem", false);
 		PVP_AMOUNT1 = config.getInt("PvpAmount1", 500);
 		PVP_AMOUNT2 = config.getInt("PvpAmount2", 1000);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpTitleColorConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/PvpTitleColorConfig.java
@@ -49,7 +49,7 @@ public class PvpTitleColorConfig
 	public static String TITLE_FOR_PVP_AMOUNT4;
 	public static String TITLE_FOR_PVP_AMOUNT5;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(PVP_TITLE_CONFIG_FILE);
 		PVP_COLOR_SYSTEM_ENABLED = config.getBoolean("EnablePvPColorSystem", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/RandomSpawnsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/RandomSpawnsConfig.java
@@ -40,7 +40,7 @@ public class RandomSpawnsConfig
 	public static int MOB_MIN_SPAWN_RANGE;
 	public static Set<Integer> MOBS_LIST_NOT_RANDOM;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(RANDOM_SPAWNS_CONFIG_FILE);
 		ENABLE_RANDOM_MONSTER_SPAWNS = config.getBoolean("EnableRandomMonsterSpawns", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/RandomSpawnsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/RandomSpawnsConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class RandomSpawnsConfig
 {
-	// File
-	private static final String RANDOM_SPAWNS_CONFIG_FILE = "./config/Custom/RandomSpawns.ini";
-	
 	// Constants
 	public static boolean ENABLE_RANDOM_MONSTER_SPAWNS;
 	public static int MOB_MAX_SPAWN_RANGE;
@@ -42,7 +39,8 @@ public class RandomSpawnsConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(RANDOM_SPAWNS_CONFIG_FILE);
+		String randomSpawnsConfigFile = String.format("./%s/Custom/RandomSpawns.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(randomSpawnsConfigFile);
 		ENABLE_RANDOM_MONSTER_SPAWNS = config.getBoolean("EnableRandomMonsterSpawns", false);
 		MOB_MAX_SPAWN_RANGE = config.getInt("MaxSpawnMobRange", 150);
 		MOB_MIN_SPAWN_RANGE = MOB_MAX_SPAWN_RANGE * -1;

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SchemeBufferConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SchemeBufferConfig.java
@@ -36,7 +36,7 @@ public class SchemeBufferConfig
 	public static int BUFFER_ITEM_ID;
 	public static int BUFFER_STATIC_BUFF_COST;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(SCHEME_BUFFER_CONFIG_FILE);
 		BUFFER_MAX_SCHEMES = config.getInt("BufferMaxSchemesPerChar", 4);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SchemeBufferConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SchemeBufferConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class SchemeBufferConfig
 {
-	// File
-	private static final String SCHEME_BUFFER_CONFIG_FILE = "./config/Custom/SchemeBuffer.ini";
-	
 	// Constants
 	public static int BUFFER_MAX_SCHEMES;
 	public static int BUFFER_ITEM_ID;
@@ -38,7 +35,8 @@ public class SchemeBufferConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SCHEME_BUFFER_CONFIG_FILE);
+		String schemeBufferConfigFile = String.format("./%s/Custom/SchemeBuffer.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(schemeBufferConfigFile);
 		BUFFER_MAX_SCHEMES = config.getInt("BufferMaxSchemesPerChar", 4);
 		BUFFER_ITEM_ID = config.getInt("BufferItemId", 57);
 		BUFFER_STATIC_BUFF_COST = config.getInt("BufferStaticCostPerBuff", -1);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ScreenWelcomeMessageConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ScreenWelcomeMessageConfig.java
@@ -36,7 +36,7 @@ public class ScreenWelcomeMessageConfig
 	public static String WELCOME_MESSAGE_TEXT;
 	public static int WELCOME_MESSAGE_TIME;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(SCREEN_WELCOME_MESSAGE_CONFIG_FILE);
 		WELCOME_MESSAGE_ENABLED = config.getBoolean("ScreenWelcomeMessageEnable", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ScreenWelcomeMessageConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ScreenWelcomeMessageConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class ScreenWelcomeMessageConfig
 {
-	// File
-	private static final String SCREEN_WELCOME_MESSAGE_CONFIG_FILE = "./config/Custom/ScreenWelcomeMessage.ini";
-	
 	// Constants
 	public static boolean WELCOME_MESSAGE_ENABLED;
 	public static String WELCOME_MESSAGE_TEXT;
@@ -38,7 +35,8 @@ public class ScreenWelcomeMessageConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SCREEN_WELCOME_MESSAGE_CONFIG_FILE);
+		String screenWelcomeMessageConfigFile = String.format("./%s/Custom/ScreenWelcomeMessage.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(screenWelcomeMessageConfigFile);
 		WELCOME_MESSAGE_ENABLED = config.getBoolean("ScreenWelcomeMessageEnable", false);
 		WELCOME_MESSAGE_TEXT = config.getString("ScreenWelcomeMessageText", "Welcome to our server!");
 		WELCOME_MESSAGE_TIME = config.getInt("ScreenWelcomeMessageTime", 10) * 1000;

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SellBuffsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SellBuffsConfig.java
@@ -39,7 +39,7 @@ public class SellBuffsConfig
 	public static long SELLBUFF_MAX_PRICE;
 	public static int SELLBUFF_MAX_BUFFS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(SELL_BUFFS_CONFIG_FILE);
 		SELLBUFF_ENABLED = config.getBoolean("SellBuffEnable", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SellBuffsConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/SellBuffsConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class SellBuffsConfig
 {
-	// File
-	private static final String SELL_BUFFS_CONFIG_FILE = "./config/Custom/SellBuffs.ini";
-	
 	// Constants
 	public static boolean SELLBUFF_ENABLED;
 	public static int SELLBUFF_MP_MULTIPLER;
@@ -41,7 +38,8 @@ public class SellBuffsConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SELL_BUFFS_CONFIG_FILE);
+		String sellBuffsConfigFile = String.format("./%s/Custom/SellBuffs.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(sellBuffsConfigFile);
 		SELLBUFF_ENABLED = config.getBoolean("SellBuffEnable", false);
 		SELLBUFF_MP_MULTIPLER = config.getInt("MpCostMultipler", 1);
 		SELLBUFF_PAYMENT_ID = config.getInt("PaymentID", 57);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ServerTimeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ServerTimeConfig.java
@@ -34,7 +34,7 @@ public class ServerTimeConfig
 	// Constant
 	public static boolean DISPLAY_SERVER_TIME;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(SERVER_TIME_CONFIG_FILE);
 		DISPLAY_SERVER_TIME = config.getBoolean("DisplayServerTime", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ServerTimeConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/ServerTimeConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class ServerTimeConfig
 {
-	// File
-	private static final String SERVER_TIME_CONFIG_FILE = "./config/Custom/ServerTime.ini";
-	
 	// Constant
 	public static boolean DISPLAY_SERVER_TIME;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SERVER_TIME_CONFIG_FILE);
+		String serverTimeConfigFile = String.format("./%s/Custom/ServerTime.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(serverTimeConfigFile);
 		DISPLAY_SERVER_TIME = config.getBoolean("DisplayServerTime", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingLocationConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingLocationConfig.java
@@ -37,7 +37,7 @@ public class StartingLocationConfig
 	public static int CUSTOM_STARTING_LOC_Y;
 	public static int CUSTOM_STARTING_LOC_Z;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(STARTING_LOCATION_CONFIG_FILE);
 		CUSTOM_STARTING_LOC = config.getBoolean("CustomStartingLocation", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingLocationConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingLocationConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class StartingLocationConfig
 {
-	// File
-	private static final String STARTING_LOCATION_CONFIG_FILE = "./config/Custom/StartingLocation.ini";
-	
 	// Constants
 	public static boolean CUSTOM_STARTING_LOC;
 	public static int CUSTOM_STARTING_LOC_X;
@@ -39,7 +36,8 @@ public class StartingLocationConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(STARTING_LOCATION_CONFIG_FILE);
+		String startingLocationConfigFile = String.format("./%s/Custom/StartingLocation.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(startingLocationConfigFile);
 		CUSTOM_STARTING_LOC = config.getBoolean("CustomStartingLocation", false);
 		CUSTOM_STARTING_LOC_X = config.getInt("CustomStartingLocX", 50821);
 		CUSTOM_STARTING_LOC_Y = config.getInt("CustomStartingLocY", 186527);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingTitleConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingTitleConfig.java
@@ -35,7 +35,7 @@ public class StartingTitleConfig
 	public static boolean ENABLE_CUSTOM_STARTING_TITLE;
 	public static String CUSTOM_STARTING_TITLE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(STARTING_TITLE_CONFIG_FILE);
 		ENABLE_CUSTOM_STARTING_TITLE = config.getBoolean("EnableStartingTitle", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingTitleConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/StartingTitleConfig.java
@@ -28,16 +28,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class StartingTitleConfig
 {
-	// File
-	private static final String STARTING_TITLE_CONFIG_FILE = "./config/Custom/StartingTitle.ini";
-	
 	// Constants
 	public static boolean ENABLE_CUSTOM_STARTING_TITLE;
 	public static String CUSTOM_STARTING_TITLE;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(STARTING_TITLE_CONFIG_FILE);
+		String startingTitleConfigFile = String.format("./%s/Custom/StartingTitle.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(startingTitleConfigFile);
 		ENABLE_CUSTOM_STARTING_TITLE = config.getBoolean("EnableStartingTitle", false);
 		CUSTOM_STARTING_TITLE = config.getString("StartingTitle", "Newbie");
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/TransmogConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/TransmogConfig.java
@@ -41,7 +41,7 @@ public class TransmogConfig
 	public static int TRANSMOG_REMOVE_COST;
 	public static Set<Integer> TRANSMOG_BANNED_ITEM_IDS = new HashSet<>();
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(TRANSMOG_CONFIG_FILE);
 		ENABLE_TRANSMOG = config.getBoolean("TransmogEnabled", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/TransmogConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/TransmogConfig.java
@@ -31,9 +31,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class TransmogConfig
 {
-	// File
-	private static final String TRANSMOG_CONFIG_FILE = "./config/Custom/Transmog.ini";
-	
 	// Constants
 	public static boolean ENABLE_TRANSMOG;
 	public static boolean TRANSMOG_SHARE_ACCOUNT;
@@ -43,7 +40,8 @@ public class TransmogConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(TRANSMOG_CONFIG_FILE);
+		String transmogConfigFile = String.format("./%s/Custom/Transmog.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(transmogConfigFile);
 		ENABLE_TRANSMOG = config.getBoolean("TransmogEnabled", false);
 		TRANSMOG_SHARE_ACCOUNT = config.getBoolean("TransmogShareAccount", false);
 		TRANSMOG_APPLY_COST = config.getInt("TransmogApplyCost", 0);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WalkerBotProtectionConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WalkerBotProtectionConfig.java
@@ -28,15 +28,13 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class WalkerBotProtectionConfig
 {
-	// File
-	private static final String WALKER_BOT_PROTECTION_CONFIG_FILE = "./config/Custom/WalkerBotProtection.ini";
-	
 	// Constants
 	public static boolean L2WALKER_PROTECTION;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(WALKER_BOT_PROTECTION_CONFIG_FILE);
+		String walkerBotProtectionConfigFile = String.format("./%s/Custom/WalkerBotProtection.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(walkerBotProtectionConfigFile);
 		L2WALKER_PROTECTION = config.getBoolean("L2WalkerProtection", false);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WalkerBotProtectionConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WalkerBotProtectionConfig.java
@@ -34,7 +34,7 @@ public class WalkerBotProtectionConfig
 	// Constants
 	public static boolean L2WALKER_PROTECTION;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(WALKER_BOT_PROTECTION_CONFIG_FILE);
 		L2WALKER_PROTECTION = config.getBoolean("L2WalkerProtection", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WarehouseSortingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WarehouseSortingConfig.java
@@ -28,16 +28,14 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class WarehouseSortingConfig
 {
-	// File
-	private static final String WAREHOUSE_SORTING_CONFIG_FILE = "./config/Custom/WarehouseSorting.ini";
-	
 	// Constants
 	public static boolean ENABLE_WAREHOUSESORTING_CLAN;
 	public static boolean ENABLE_WAREHOUSESORTING_PRIVATE;
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(WAREHOUSE_SORTING_CONFIG_FILE);
+		String warehouseSortingConfigFile = String.format("./%s/Custom/WarehouseSorting.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(warehouseSortingConfigFile);
 		ENABLE_WAREHOUSESORTING_CLAN = config.getBoolean("EnableWarehouseSortingClan", false);
 		ENABLE_WAREHOUSESORTING_PRIVATE = config.getBoolean("EnableWarehouseSortingPrivate", false);
 	}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WarehouseSortingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WarehouseSortingConfig.java
@@ -35,7 +35,7 @@ public class WarehouseSortingConfig
 	public static boolean ENABLE_WAREHOUSESORTING_CLAN;
 	public static boolean ENABLE_WAREHOUSESORTING_PRIVATE;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(WAREHOUSE_SORTING_CONFIG_FILE);
 		ENABLE_WAREHOUSESORTING_CLAN = config.getBoolean("EnableWarehouseSortingClan", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WeddingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WeddingConfig.java
@@ -42,7 +42,7 @@ public class WeddingConfig
 	public static boolean WEDDING_FORMALWEAR;
 	public static int WEDDING_DIVORCE_COSTS;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
 		final ConfigReader config = new ConfigReader(WEDDING_CONFIG_FILE);
 		ALLOW_WEDDING = config.getBoolean("AllowWedding", false);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WeddingConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/config/custom/WeddingConfig.java
@@ -28,9 +28,6 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class WeddingConfig
 {
-	// File
-	private static final String WEDDING_CONFIG_FILE = "./config/Custom/Wedding.ini";
-	
 	// Constants
 	public static boolean ALLOW_WEDDING;
 	public static int WEDDING_PRICE;
@@ -44,7 +41,8 @@ public class WeddingConfig
 	
 	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(WEDDING_CONFIG_FILE);
+		String weddingConfigFile = String.format("./%s/Custom/Wedding.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(weddingConfigFile);
 		ALLOW_WEDDING = config.getBoolean("AllowWedding", false);
 		WEDDING_PRICE = config.getInt("WeddingPrice", 250000000);
 		WEDDING_PUNISH_INFIDELITY = config.getBoolean("WeddingPunishInfidelity", true);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/PhantomPartyManager.java
@@ -1133,7 +1133,7 @@ public class PhantomPartyManager
 		{
 			_pendingTrades = new CopyOnWriteArrayList<>();
 			_members.values().stream()
-					.filter(member -> member.lootingSessionItems != null && !member.lootingSessionItems.isEmpty())
+					.filter(member -> member.owner == owner && member.lootingSessionItems != null && !member.lootingSessionItems.isEmpty())
 					.collect(Collectors.toCollection(() -> _pendingTrades));
 			if (_pendingTrades.isEmpty()) {
 				return false;
@@ -1393,7 +1393,7 @@ public class PhantomPartyManager
 		if (containsAny(text, "return loot", "hand over loot", "hand over loot"))
 		{
 			Map<Integer, Integer> spoils = state.lootingSessionItems;
-			if (spoils.isEmpty()) {
+			if (spoils == null || spoils.isEmpty()) {
 				deliver(state, "nothing to hand over yet, how about a few more mobs then?");
 				return true;
 			}
@@ -2693,6 +2693,12 @@ public class PhantomPartyManager
 		if (!state.scavengerKitLookedUp) {
 			state.sweeper = npc.getKnownSkill(SWEEPER_SKILL_ID);
 			state.scavengerKitLookedUp = true;
+		}
+
+		// Without the Sweeper skill there is nothing to cast on a spoiled corpse; never enter
+		// sweeping mode, or runSweepOnSelectedCorpses would dereference a null sweeper.
+		if (state.sweeper == null) {
+			return false;
 		}
 
 		if (!state.fieldSweepingInProcess) {

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/SiegeManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/managers/SiegeManager.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 
 import org.l2jmobius.commons.database.DatabaseFactory;
 import org.l2jmobius.commons.util.ConfigReader;
+import org.l2jmobius.gameserver.config.ConfigLoader;
 import org.l2jmobius.gameserver.data.xml.SkillData;
 import org.l2jmobius.gameserver.model.Location;
 import org.l2jmobius.gameserver.model.WorldObject;
@@ -47,8 +48,6 @@ import org.l2jmobius.gameserver.model.skill.Skill;
 public class SiegeManager
 {
 	private static final Logger LOGGER = Logger.getLogger(SiegeManager.class.getName());
-	
-	private static final String SIEGE_CONFIG_FILE = "./config/Siege.ini";
 	
 	private final Map<Integer, List<TowerSpawn>> _controlTowers = new HashMap<>();
 	private final Map<Integer, List<TowerSpawn>> _flameTowers = new HashMap<>();
@@ -125,7 +124,8 @@ public class SiegeManager
 	
 	private void load()
 	{
-		final ConfigReader siegeConfig = new ConfigReader(SIEGE_CONFIG_FILE);
+		String siegeConfigFile = String.format("./%s/Siege.ini", ConfigLoader.getBaseConfigPath());
+		final ConfigReader siegeConfig = new ConfigReader(siegeConfigFile);
 		
 		// Siege configurations.
 		_siegeCycle = siegeConfig.getInt("SiegeCycle", 2);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/ui/Gui.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/ui/Gui.java
@@ -60,6 +60,7 @@ import org.l2jmobius.gameserver.data.xml.AdminData;
 import org.l2jmobius.gameserver.data.xml.BuyListData;
 import org.l2jmobius.gameserver.data.xml.MultisellData;
 import org.l2jmobius.gameserver.util.Broadcast;
+import org.l2jmobius.gameserver.util.argsparse.GameServerLaunchArgs;
 
 /**
  * @author Mobius
@@ -89,7 +90,7 @@ public class Gui
 	
 	private final JTextArea _txtrConsole;
 	
-	public Gui()
+	public Gui(GameServerLaunchArgs gameServerLaunchArgs)
 	{
 		// Disable hardware acceleration.
 		System.setProperty("sun.java2d.opengl", "false");
@@ -185,7 +186,7 @@ public class Gui
 		{
 			if (JOptionPane.showOptionDialog(null, "Reload configs?", "Select an option", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, CONFIRM_OPTIONS, CONFIRM_OPTIONS[1]) == 0)
 			{
-				ConfigLoader.init();
+				ConfigLoader.init(gameServerLaunchArgs.baseConfigPath());
 			}
 		});
 		mnReload.add(mntmConfigs);

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgs.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgs.java
@@ -1,0 +1,9 @@
+package org.l2jmobius.gameserver.util.argsparse;
+
+/**
+ * @author Heelix
+ */
+public record GameServerLaunchArgs(String baseConfigPath)
+{
+
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
@@ -1,26 +1,20 @@
 package org.l2jmobius.gameserver.util.argsparse;
 
-import java.util.Arrays;
-
 /**
  * @author Heelix
  */
 public class GameServerLaunchArgumentsParser {
 
-    private static final String CONFIG_PATH_KEY = "-DgameConfigPath";
+    private static final String CONFIG_PATH_KEY = "gameConfigPath";
     private static final String DEFAULT_CONFIG_PATH = "config";
 
     private GameServerLaunchArgumentsParser()
     {
     }
 
-    public static GameServerLaunchArgs parse(String[] args)
+    public static GameServerLaunchArgs parse()
     {
-        String baseGameConfigPath = Arrays
-                .stream(args)
-                .filter(argument -> argument.startsWith(CONFIG_PATH_KEY))
-                .findFirst()
-                .orElse(DEFAULT_CONFIG_PATH);
+        String baseGameConfigPath = System.getProperty(CONFIG_PATH_KEY, DEFAULT_CONFIG_PATH);
 
         return new GameServerLaunchArgs(baseGameConfigPath);
     }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
@@ -3,7 +3,7 @@ package org.l2jmobius.gameserver.util.argsparse;
 /**
  * @author Heelix
  */
-public class GameServerLaunchArgumentsParser {
+public final class GameServerLaunchArgumentsParser {
 
     private static final String CONFIG_PATH_KEY = "gameConfigPath";
     private static final String DEFAULT_CONFIG_PATH = "config";

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/gameserver/util/argsparse/GameServerLaunchArgumentsParser.java
@@ -1,0 +1,27 @@
+package org.l2jmobius.gameserver.util.argsparse;
+
+import java.util.Arrays;
+
+/**
+ * @author Heelix
+ */
+public class GameServerLaunchArgumentsParser {
+
+    private static final String CONFIG_PATH_KEY = "-DgameConfigPath";
+    private static final String DEFAULT_CONFIG_PATH = "config";
+
+    private GameServerLaunchArgumentsParser()
+    {
+    }
+
+    public static GameServerLaunchArgs parse(String[] args)
+    {
+        String baseGameConfigPath = Arrays
+                .stream(args)
+                .filter(argument -> argument.startsWith(CONFIG_PATH_KEY))
+                .findFirst()
+                .orElse(DEFAULT_CONFIG_PATH);
+
+        return new GameServerLaunchArgs(baseGameConfigPath);
+    }
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/LoginServer.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/LoginServer.java
@@ -43,6 +43,8 @@ import org.l2jmobius.loginserver.network.LoginClient;
 import org.l2jmobius.loginserver.network.LoginPacketHandler;
 import org.l2jmobius.loginserver.network.gameserverpackets.ServerStatus;
 import org.l2jmobius.loginserver.ui.Gui;
+import org.l2jmobius.loginserver.util.argsparse.LoginServerLaunchArgs;
+import org.l2jmobius.loginserver.util.argsparse.LoginServerLaunchArgumentsParser;
 
 /**
  * Bootstraps and drives the login server lifecycle.<br>
@@ -84,11 +86,15 @@ public class LoginServer
 	// Login server status.
 	private static volatile int _loginStatus = ServerStatus.STATUS_NORMAL;
 	
+	private final LoginServerLaunchArgs _loginServerLaunchArgs;
+	
 	/**
 	 * Creates a new login server instance and initializes all required services.
 	 */
 	private LoginServer()
 	{
+		_loginServerLaunchArgs = LoginServerLaunchArgumentsParser.parse();
+		
 		initializeInterfaceLayer();
 		initializeLoggingLayer();
 		initializeCoreServices();
@@ -102,7 +108,7 @@ public class LoginServer
 	 */
 	private void initializeInterfaceLayer()
 	{
-		InterfaceConfig.load();
+		InterfaceConfig.load(_loginServerLaunchArgs.baseConfigPath());
 		
 		if (!InterfaceConfig.ENABLE_GUI)
 		{
@@ -152,11 +158,11 @@ public class LoginServer
 	 */
 	private void initializeCoreServices()
 	{
-		LoginConfig.load();
+		LoginConfig.load(_loginServerLaunchArgs.baseConfigPath());
 		
-		DatabaseFactory.init();
+		DatabaseFactory.init(_loginServerLaunchArgs.baseConfigPath());
 		
-		ThreadPool.init();
+		ThreadPool.init(_loginServerLaunchArgs.baseConfigPath());
 		
 		try
 		{

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/config/LoginConfig.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/config/LoginConfig.java
@@ -35,9 +35,6 @@ public class LoginConfig
 {
 	private static final Logger LOGGER = Logger.getLogger(LoginConfig.class.getName());
 	
-	// File
-	private static final String SERVER_CONFIG_FILE = "./config/Server.ini";
-	
 	// Constants
 	public static int GAME_SERVER_LOGIN_PORT;
 	public static String GAME_SERVER_LOGIN_HOST;
@@ -57,9 +54,10 @@ public class LoginConfig
 	public static int FAST_CONNECTION_TIME;
 	public static int MAX_CONNECTION_PER_IP;
 	
-	public static void load()
+	public static void load(String baseConfigPath)
 	{
-		final ConfigReader config = new ConfigReader(SERVER_CONFIG_FILE);
+		String serverConfigFile = String.format("./%s/Server.ini", baseConfigPath);
+		final ConfigReader config = new ConfigReader(serverConfigFile);
 		GAME_SERVER_LOGIN_HOST = config.getString("LoginHostname", "127.0.0.1");
 		GAME_SERVER_LOGIN_PORT = config.getInt("LoginPort", 9013);
 		LOGIN_BIND_ADDRESS = config.getString("LoginserverHostname", "0.0.0.0");

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/util/argsparse/LoginServerLaunchArgs.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/util/argsparse/LoginServerLaunchArgs.java
@@ -1,0 +1,9 @@
+package org.l2jmobius.loginserver.util.argsparse;
+
+/**
+ * @author Heelix
+ */
+public record LoginServerLaunchArgs(String baseConfigPath)
+{
+
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/util/argsparse/LoginServerLaunchArgumentsParser.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/loginserver/util/argsparse/LoginServerLaunchArgumentsParser.java
@@ -1,0 +1,22 @@
+package org.l2jmobius.loginserver.util.argsparse;
+
+/**
+ * @author Heelix
+ */
+public final class LoginServerLaunchArgumentsParser
+{
+
+    private static final String CONFIG_PATH_KEY = "loginConfigPath";
+    private static final String DEFAULT_CONFIG_PATH = "config";
+
+    private LoginServerLaunchArgumentsParser()
+    {
+    }
+
+    public static LoginServerLaunchArgs parse()
+    {
+        String baseGameConfigPath = System.getProperty(CONFIG_PATH_KEY, DEFAULT_CONFIG_PATH);
+
+        return new LoginServerLaunchArgs(baseGameConfigPath);
+    }
+}

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/AccountManager.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/AccountManager.java
@@ -93,6 +93,7 @@ import org.l2jmobius.commons.database.DatabaseFactory;
 import org.l2jmobius.commons.time.TimeUtil;
 import org.l2jmobius.commons.ui.DarkTheme;
 import org.l2jmobius.commons.ui.SplashScreen;
+import org.l2jmobius.loginserver.util.argsparse.LoginServerLaunchArgumentsParser;
 
 /**
  * @author Skache
@@ -1671,8 +1672,9 @@ public class AccountManager extends JFrame
 	
 	public static void main(String[] args)
 	{
-		InterfaceConfig.load();
-		DatabaseFactory.init();
+		final String baseConfigPath = LoginServerLaunchArgumentsParser.parse().baseConfigPath();
+		InterfaceConfig.load(baseConfigPath);
+		DatabaseFactory.init(baseConfigPath);
 		SwingUtilities.invokeLater(AccountManager::new);
 	}
 }

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/DatabaseInstaller.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/DatabaseInstaller.java
@@ -76,7 +76,7 @@ import org.l2jmobius.commons.util.ConfigReader;
  */
 public class DatabaseInstaller extends JFrame
 {
-	public static final String INTERFACE_CONFIG_FILE = "./config/Interface.ini";
+	public static final String INTERFACE_CONFIG_FILE = String.format("./%s/Interface.ini", System.getProperty("gameConfigPath", "config"));
 	
 	private JTextField _hostField;
 	private JTextField _portField;

--- a/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/GameServerRegister.java
+++ b/L2J_Mobius_CT_0_Interlude github/java/org/l2jmobius/tools/GameServerRegister.java
@@ -70,6 +70,7 @@ import org.l2jmobius.commons.ui.DarkTheme;
 import org.l2jmobius.commons.ui.SplashScreen;
 import org.l2jmobius.commons.util.HexUtil;
 import org.l2jmobius.loginserver.GameServerTable;
+import org.l2jmobius.loginserver.util.argsparse.LoginServerLaunchArgumentsParser;
 
 /**
  * @author Skache
@@ -812,8 +813,9 @@ public class GameServerRegister extends JFrame
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			InterfaceConfig.load();
-			DatabaseFactory.init(); // Initialize the database connection.
+			final String baseConfigPath = LoginServerLaunchArgumentsParser.parse().baseConfigPath();
+			InterfaceConfig.load(baseConfigPath);
+			DatabaseFactory.init(baseConfigPath); // Initialize the database connection.
 			GameServerTable.getInstance(); // Initialize the GameServerTable.
 			new GameServerRegister();
 		});


### PR DESCRIPTION
### Why

These changes came out of a need to separate the configs shipped with every release
build from the configs a developer actually uses while working on a feature.

In my case, I pointed the server at a development database instead of the production
one and tweaked a few server settings — rates, buff durations and so on. Committing
those changes to the main repository was obviously not an option.

The goal is to remove a recurring annoyance: having to strip local config changes out
of the working tree before every commit.

### How to use

The `GameServer.jar` and `LoginServer.jar` build scripts now recognise two new
parameters, `-DloginConfigPath` and `-DgameConfigPath`. Developers can point them at a
local config folder in their dev environment; release builds are unaffected.

Setup:

1. Create a folder named `devconfig` in `L2J_Mobius_CT_0_Interlude github/dist/game`
   and copy the contents of `config` into it. Do the same for the login server.

2. Pass the new parameters to the JVM. Either edit
   `L2J_Mobius_CT_0_Interlude github/dist/game/java.cfg` so the line reads:

   ```
   -server -Dfile.encoding=UTF-8 -Djava.util.logging.manager=org.l2jmobius.log.ServerLogManager -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=warn -XX:+UseZGC -Xmx4g -Xms2g -DgameConfigPath=devconfig -DloginConfigPath=devconfig
   ```

   …or, if you work in IntelliJ IDEA, add the same parameters to the run
   configurations for both the Login Server and the Game Server:

   <img width="1280" height="724" alt="IntelliJ IDEA run configuration" src="https://github.com/user-attachments/assets/998901bd-bc25-4887-9d7b-2947f4b5e507" />

3. Edit the files in `devconfig` as needed. Both `devconfig` folders are listed in
   `.gitignore`, so local changes never touch the configs in the repository.